### PR TITLE
Justice Fixes

### DIFF
--- a/vme/zone/justice.zon
+++ b/vme/zone/justice.zon
@@ -781,8 +781,10 @@ code
    while(suspects)
    {
       if ("$crime" in suspects.names) 
-         local_suspects := local_suspects + suspects.descr+"<BR>";
-       else if ("$arrest" in suspects.names)
+      {  if(suspects.names.[9] == "0")
+           local_suspects := local_suspects + suspects.descr+"<BR>";
+      }
+      else if ("$arrest" in suspects.names)
          wanted_alive := wanted_alive + suspects.descr+ "<br>"; 
        else if ("$reward" in suspects.names)
          wanted_dead := wanted_dead + suspects.descr+ "<BR>"; 

--- a/vme/zone/midgaard.zon
+++ b/vme/zone/midgaard.zon
@@ -1009,10 +1009,13 @@ code
    
 // Change player arrest descr to reflect that the char is in jail.
 
+if ("$arrest" in self.extra)
+{
    jd := findsymbolic("database@justice");
    id := self.extra.["$arrest"].names.[1];
    jd.extra.[id].descr := self.name+" is currently serving time in jail.";
- 
+} 
+
    :loop:
    pause;
 


### PR DESCRIPTION
FIxed:
Suspects will no longer be displayed on the wanted_poster after a successful accusation
Do not update the jail status of players who are arrested without an $arrest extra.