### PR TITLE
Restructure mana/hp/endurance regeneration

### DIFF
--- a/vme/include/values.h
+++ b/vme/include/values.h
@@ -1222,6 +1222,8 @@ ACTION
 #define DIL_GINT_DESCRIPTOR 3  // returns 0 if PC has no descriptor. 1 for all else
 #define DIL_GINT_CRIMENO    4  // returns the next crime_no
 #define DIL_GINT_MANAREG    5  // returns the amount of mana PC/NPC should regenerate
+#define DIL_GINT_HITREG     6  // returns the amount of hp PC/NPC should regenerate
+#define DIL_GINT_MOVEREG    7  // returns the amount of endurance PC/NPC should regenerate
 
 #endif /* _MUD_VALUES_H */
 

--- a/vme/include/values.h
+++ b/vme/include/values.h
@@ -1221,7 +1221,7 @@ ACTION
 #define DIL_GINT_LEVELXP    2  // return the level_xp(i) (XP needed for level i->i+1)
 #define DIL_GINT_DESCRIPTOR 3  // returns 0 if PC has no descriptor. 1 for all else
 #define DIL_GINT_CRIMENO    4  // returns the next crime_no
-
+#define DIL_GINT_MANAREG    5  // returns the amount of mana PC/NPC should regenerate
 
 #endif /* _MUD_VALUES_H */
 

--- a/vme/src/dilexp.cpp
+++ b/vme/src/dilexp.cpp
@@ -3352,6 +3352,11 @@ void dilfe_gint(register class dilprg *p)
     {
         switch (idx)
         {
+        case DIL_GINT_MANAREG:
+          if ((p_u != NULL) && IS_CHAR(p_u))
+                v->val.num = mana_gain(p_u);
+          break;
+
         case DIL_GINT_EFFDEX:
             if ((p_u != NULL) && IS_CHAR(p_u))
                 v->val.num = effective_dex(p_u);

--- a/vme/src/dilexp.cpp
+++ b/vme/src/dilexp.cpp
@@ -3353,9 +3353,19 @@ void dilfe_gint(register class dilprg *p)
         switch (idx)
         {
         case DIL_GINT_MANAREG:
-          if ((p_u != NULL) && IS_CHAR(p_u))
+            if ((p_u != NULL) && IS_CHAR(p_u))
                 v->val.num = mana_gain(p_u);
-          break;
+            break;
+
+        case DIL_GINT_HITREG:
+            if ((p_u != NULL) && IS_CHAR(p_u))
+                v->val.num = hit_gain(p_u);
+            break;
+
+        case DIL_GINT_MOVEREG:
+            if ((p_u != NULL) && IS_CHAR(p_u))
+                v->val.num = move_gain(p_u);
+            break;
 
         case DIL_GINT_EFFDEX:
             if ((p_u != NULL) && IS_CHAR(p_u))

--- a/vme/zone/update.zon
+++ b/vme/zone/update.zon
@@ -262,78 +262,10 @@ code
 dilend
 
 
-dilbegin integer mana_gain (pc:unitptr);
-var
-    gain:integer;
-    u:unitptr;
-    bonus : integer;
-code
-{
-    if      (pc.race == RACE_HUMAN)     bonus := 1;
-    else if (pc.race == RACE_DWARF)     bonus := -2;
-    else if (pc.race == RACE_HALFLING)  bonus := -5;
-    else if (pc.race == RACE_GNOME)     bonus := 2 ;
-    else if (pc.race == RACE_ELF)       bonus := 5 ;
-    else if (pc.race == RACE_HALF_ELF)  bonus := 3 ;
-    else if (pc.race == RACE_DARK_ELF)  bonus := 5 ;
-    else if (pc.race == RACE_BROWNIE)   bonus := 5;
-    else if (pc.race == RACE_GROLL)     bonus := -5;
-    else if (pc.race == RACE_HALF_ORC)  bonus := -5;
-    else if (pc.race == RACE_HALF_OGRE) bonus := -3;
-    else  bonus := 1;
-
-    if (pc.position!=POSITION_FIGHTING)
-    {
-        gain := bonus + pc.max_mana/ 10;
-        if (pc.abilities[ABIL_MAG]>pc.abilities[ABIL_DIV])
-            gain :=gain+ (pc.abilities[ABIL_CHA] -pc.abilities[ABIL_MAG])/3;
-        else
-            gain :=gain+ (pc.abilities[ABIL_CHA] -pc.abilities[ABIL_DIV])/3;
-
-        if ((pc.abilities[ABIL_CHA] > 0) and (gain < 1 ))
-            gain :=1;
-
-    }
-    else
-        gain:=0;
-
-    if ((pc.position==POSITION_SLEEPING) or (pc.position==POSITION_RESTING))
-      gain := gain+ (gain / 2);     /* gain *= 1.5  */
-    else if (pc.position==POSITION_SITTING)
-      gain := gain+ (gain / 4);/*gain = 1.25*/
-
-    u:=pc;
-    while (u)
-    {
-        if (isset(u.flags,UNIT_FL_SACRED))
-        {
-            gain:=gain*2;
-            break;
-        }
-        if (u.type==UNIT_ST_ROOM)
-            break;
-        u:=u.outside;
-    }
-
-    if (pc.type==UNIT_ST_PC)
-    {
-        if ((pc.full<0) or (pc.thirst<0))
-            if ((3*pc.thirst)<pc.full)
-                gain:=gain+9*pc.thirst;
-            else
-                gain:=gain+3*pc.full;
-    }
-
-    return (gain);
-}
-dilend
-
-
 // NPCs only
 dilbegin unique fnpri(FN_PRI_BODY) regenerate();
 external
    integer hit_gain(u:unitptr);
-   integer mana_gain(u:unitptr);
    integer move_gain(u:unitptr);
 
 var
@@ -354,7 +286,7 @@ code
    if (self.position >= POSITION_STUNNED)
    {
       hgain := hit_gain(self);
-      mgain := mana_gain(self);
+      mgain := getinteger(DIL_GINT_MANAREG, self, 0);
       egain := 2 * move_gain(self);
 
       if ((self.mana+mgain)>self.max_mana)
@@ -400,7 +332,6 @@ dilend
 dilbegin unique fnpri(FN_PRI_BODY-1) regen_pc();
 external
     integer hit_gain(u:unitptr);
-    integer mana_gain(u:unitptr);
     integer move_gain(u:unitptr);
     gain_cond (u:unitptr,cond:string,i:integer);
 var
@@ -427,7 +358,7 @@ code
     if (self.position>=POSITION_STUNNED)
     {
         hgain:=hit_gain(self);
-        mgain:=mana_gain(self);
+        mgain:=getinteger(DIL_GINT_MANAREG, self, 0);
         egain:=move_gain(self);
 
         if ((self.mana+mgain)>self.max_mana)

--- a/vme/zone/update.zon
+++ b/vme/zone/update.zon
@@ -128,146 +128,8 @@ code
 dilend
 
 
-/* Hitpoint gain pr. game hour */
-dilbegin integer hit_gain(pc:unitptr);
-var
-    gain:integer;
-    u:unitptr;
-    hitln:integer;
-    bonus: integer;
-code
-{
-    if      (pc.race == RACE_HUMAN)     bonus := 1;
-    else if (pc.race == RACE_DWARF)     bonus := 5;
-    else if (pc.race == RACE_HALFLING)  bonus := -1;
-    else if (pc.race == RACE_GNOME)     bonus := 4 ;
-    else if (pc.race == RACE_ELF)       bonus := 1 ;
-    else if (pc.race == RACE_HALF_ELF)  bonus := 1 ;
-    else if (pc.race == RACE_DARK_ELF)  bonus :=1 ;
-    else if (pc.race == RACE_BROWNIE)   bonus := -5;
-    else if (pc.race == RACE_GROLL)     bonus := 5;
-    else if (pc.race == RACE_HALF_ORC)  bonus := 4;
-    else if (pc.race == RACE_HALF_OGRE) bonus :=5;
-    else  bonus := 1;
-
-    if (pc.level <= 20 ) 
-      bonus := 5;
-
-    /* 10 turns to regenerate */
-    if (pc.position!=POSITION_FIGHTING)
-        gain:=bonus+(((pc.abilities[ABIL_CON]/10)+(pc.max_hp/10))/4)
-    else
-        gain:=0;
-
-    if ((pc.abilities[ABIL_CON] > 0) and (gain < 1 ))
-      gain :=1;
-
-    if ((pc.position==POSITION_SLEEPING) or (pc.position==POSITION_RESTING))
-        gain := gain + (gain / 2);     /* gain *= 1.5  */
-    else if (pc.position==POSITION_SITTING)
-      gain := gain + (gain / 4); /* gain = 1.25*/
-
-    u:=pc;
-    while (u)
-    {
-        if (isset(u.flags, UNIT_FL_SACRED))
-        {
-          gain:=gain*2;
-          break;
-        }
-        if (u.type == UNIT_ST_ROOM)
-          break;
-        u:=u.outside;
-    }
-
-    if (pc.type == UNIT_ST_PC)
-    {
-        if (getinteger(DIL_GINT_DESCRIPTOR, pc, 0) == 0)
-        {
-            log("No descriptor, no food adjustment");
-            log("No descriptor " + pc.name);
-            return(gain);
-        }
-
-        if ((pc.full<0) or (pc.thirst<0))
-          if ((3*pc.thirst)<pc.full)
-              gain:=gain+9*pc.thirst;
-          else
-              gain:=gain+3*pc.full;
-    }
-
-    return(gain);
-}
-dilend
-
-
-/* move gain pr. game hour */
-dilbegin integer move_gain(pc:unitptr);
-var
-    gain:integer;
-    u:unitptr;
-    bonus : integer;
-code
-{
-    if      (pc.race == RACE_HUMAN)     bonus := 1;
-    else if (pc.race == RACE_DWARF)     bonus := 3;
-    else if (pc.race == RACE_HALFLING)  bonus := 5;
-    else if (pc.race == RACE_GNOME)     bonus := 2 ;
-    else if (pc.race == RACE_ELF)       bonus := 3 ;
-    else if (pc.race == RACE_HALF_ELF)  bonus := 2 ;
-    else if (pc.race == RACE_DARK_ELF)  bonus := -3 ;
-    else if (pc.race == RACE_BROWNIE)   bonus := -1;
-    else if (pc.race == RACE_GROLL)     bonus := -3;
-    else if (pc.race == RACE_HALF_ORC)  bonus :=  4;
-    else if (pc.race == RACE_HALF_OGRE) bonus :=  4;
-    else  bonus := 1;
-
-    if (pc.position!=POSITION_FIGHTING)
-      gain := bonus + (pc.max_endurance  / 10); /* 10 turns to regenerate */
-    else
-      gain := 0;
-
-    if ((pc.abilities[ABIL_CON] > 0) and (gain < 1 ))
-      gain :=1;
-
-    if ((pc.position==POSITION_SLEEPING) or (pc.position==POSITION_RESTING))
-        gain := gain+ (gain / 2);     /* gain *= 1.5  */
-    else if (pc.position==POSITION_SITTING)
-        gain := gain+ (gain / 4);/*gain = 1.25*/
-
-    u:=pc;
-    while (u)
-    {
-        if (isset(u.flags,UNIT_FL_SACRED))
-        {
-            gain:=gain*2;
-            break;
-        }
-        if (u.type==UNIT_ST_ROOM)
-            break;
-        u:=u.outside;
-    }
-
-    if (pc.type==UNIT_ST_PC)
-    {
-        if ((pc.full<0) or (pc.thirst<0))
-            if ((3*pc.thirst)<pc.full)
-                gain:=gain+9*pc.thirst;
-            else
-                gain:=gain+3*pc.full;
-    }
-
-    return (gain);
-}
-dilend
-
-
 // NPCs only
 dilbegin unique fnpri(FN_PRI_BODY) regenerate();
-external
-   integer hit_gain(u:unitptr);
-   integer move_gain(u:unitptr);
-
 var
    hgain:integer;
    mgain:integer;
@@ -285,9 +147,9 @@ code
 
    if (self.position >= POSITION_STUNNED)
    {
-      hgain := hit_gain(self);
+      hgain := getinteger(DIL_GINT_HITREG, self, 0);
       mgain := getinteger(DIL_GINT_MANAREG, self, 0);
-      egain := 2 * move_gain(self);
+      egain := 2 * getinteger(DIL_GINT_MOVEREG, self, 0);
 
       if ((self.mana+mgain)>self.max_mana)
          self.mana:=self.max_mana;
@@ -331,8 +193,6 @@ dilend
 // PCs only
 dilbegin unique fnpri(FN_PRI_BODY-1) regen_pc();
 external
-    integer hit_gain(u:unitptr);
-    integer move_gain(u:unitptr);
     gain_cond (u:unitptr,cond:string,i:integer);
 var
     hgain:integer;
@@ -357,9 +217,9 @@ code
 
     if (self.position>=POSITION_STUNNED)
     {
-        hgain:=hit_gain(self);
-        mgain:=getinteger(DIL_GINT_MANAREG, self, 0);
-        egain:=move_gain(self);
+        hgain := getinteger(DIL_GINT_HITREG, self, 0);
+        mgain := getinteger(DIL_GINT_MANAREG, self, 0);
+        egain := getinteger(DIL_GINT_MOVEREG, self, 0);
 
         if ((self.mana+mgain)>self.max_mana)
           self.mana:=self.max_mana;


### PR DESCRIPTION
Modifies mana/hp/endurance regen on-tick to only use the c++ implementations.

From conversation earlier, my impression is that the cpp implementations are intended to be 'canonical'. As such I haven't modified them but instead noted differences from the actual DIL that is currently being used.

All:
  - Race is no longer a factor in regeneration. I think this will be noticed primarily by oldbies, whose elves will have 4 less mana per tick.

Mana:
  - Ticks can no longer be negative if a player has 0 charisma.

Hitpoints:
  - PCs < level 20 had a guaranteed racial bonus of 5 (so 4 more pase per tick than now)
  - HP used to be based on:
    : `1 + (con / 10 + max_hp / 10) / 4`
    but is now
    : `(max_hp / 10)`
    which is presumably an increase in most cases, unless a character had a ton of con and not many hitpoints. With a test newbie, this actually made HP regeneration break even at level 1 even without the previous <lv20 bonus.
  - Thirst was more punitive than hunger. They are now equal.

Endurance:
  - Thirst was more punitive than hunger. They are now equal.
