### PR TITLE
Fixes for Rogue Quest

### DIFF
--- a/vme/zone/gremlin.zon
+++ b/vme/zone/gremlin.zon
@@ -396,7 +396,7 @@ code
 		exec("say Ah-har, matey. This smells like it could strip the paint off a hull!", self);
 		destroy(self.inside);
 	}
-	else if ((22 == self.inside.type) and (not(ROGUE_COMPLETE in activator.quests)))
+	else if ((ITEM_BOAT == self.inside.objecttype) and (not(ROGUE_COMPLETE in activator.quests)))
 	{
 		addstring(exdp.names, "boat");
 		exec("say Ah-har, matey. She aint pretty, but she looks to float.", self);
@@ -404,6 +404,7 @@ code
 	}
 	else
 	{
+		destroy(self.inside);
 		exec("say No, "+pc.name +", I dont need this.", self);
 		pause;
 	}


### PR DESCRIPTION
Changes self.inside.type to self.inside.objecttype when NPC Sventer receives a boat type item, and switched to using ITEM_BOAT macro instead of "22" to match on it.  Destroyed items given to the Rogue that aren't on the quest items list to avoid the rogue being overburdened by non-boat items.