### PR TITLE
Adding Completion Flag to BOLDIN_ROGUE Quest

### DIFF
--- a/vme/zone/gremlin.zon
+++ b/vme/zone/gremlin.zon
@@ -334,6 +334,7 @@ code
 	{
 		subextra(pc.quests, ROGUE_ONGOING);
 		addextra(pc.quests, {ROGUE_COMPLETE}, "");
+		exdp := qstSetDone@quests(BOLDIN_ROGUE, pc);
 		experience(3000, pc);
 		act("<br><div class='hint'>Quest Completed!</div>",A_SOMEONE, pc, null, null, TO_CHAR); 
 		act("<br><div class='xpgain'>You recieve 3000 experience.</div><br>",A_SOMEONE, pc, null, null, TO_CHAR); 


### PR DESCRIPTION
Noticed the Rogue Quest dialog re-commences for players who had completed the quest.  Looks like there's another leg planned for this quest line as well.  However, adding the quest complete flag for THIS leg using the quests API, to keep them from farming XP this way.

Just  added:       exdp := qstSetDone@quests(BOLDIN_ROGUE, pc); before the quest reward is provided.