### PR TITLE
Minor Newbies Quest Change, Per Bug Report

### DIFF
--- a/vme/zone/newbie.zon
+++ b/vme/zone/newbie.zon
@@ -1316,11 +1316,11 @@ A_ALWAYS , self, null , pc ,TO_VICT);
 pause;
 act ("$1n says 'type 'write letter' now and write a note saying Hi and "+
 "introducing yourself to the council.  When you are done with your note you can exit the editor by "+
-      "typing '@' on a blank line and hitting <enter>.'",
+      "typing the at-sign '@' on a blank line and hitting <enter>.'",
 A_ALWAYS , self, null , pc ,TO_VICT);
 pause;
 
-act ("$1n says 'When you are done writing just say 'DONE' and I will tell you what to do next.'",
+act ("$1n says 'When you are done writing just type 'say DONE' and I will tell you what to do next.'",
 A_ALWAYS , self, null , pc ,TO_VICT);
 pause;
 act ("$1n says 'I will not respond again until you tell me you are done.'",


### PR DESCRIPTION
Corrected the language to tell the player to type the "say" keyword in front of "DONE" for clarity, per one player complaint.  Also spelled out "at-sign" before "@" in the preceding instruction as some screen-readers may display that as "at", making the instructions difficult for unsighted players.

Original Report:
@Moth bug report: postoffice@udgaard [Moth] Tue Apr 20 09:16:49 2021
"i wrote DONE and it doesn't do anything"