### PR TITLE
Rogue Quest Zone Wander Time Fix

### DIFF
--- a/vme/zone/gremlin.zon
+++ b/vme/zone/gremlin.zon
@@ -1770,7 +1770,7 @@ with a blade of one form or another. He is cowled in a dark cloak, and has a gle
 M_HUMAN_THIEF_AXE(30,SEX_MALE)
 money 1 GOLD_PIECE
 
-dilcopy wander_zones@function ("torsbay", 30, 0,0);
+dilcopy wander_zones@function ("torsbay", 180, 0,0);
 dilcopy rogue_request@gremlin();
 dilcopy rogue_give@gremlin();
 end


### PR DESCRIPTION
Sventer takes up to two minutes to get out all of his quest dialogue before the player can accept the quest, causing the player to chase him around the zone hoping to be able to "nod" to accept it.  This fix increases the minimum wait time between his moves to 180 seconds up from 30 seconds.