### PR TITLE
Fixed Odin's Medallion for Conjurer's Guild

### DIFF
--- a/vme/zone/guild_paths.zon
+++ b/vme/zone/guild_paths.zon
@@ -799,7 +799,7 @@ code
    addstring(dest_list, "fighter"); 	// 0
    addstring(dest_list, "thief"); 		// 1
    addstring(dest_list, "healer"); 		// 2
-   addstring(dest_list, "mage"); 		// 3
+   addstring(dest_list, "conjurer"); 		// 3
    addstring(dest_list, "ranger"); 		// 4
    addstring(dest_list, "paladin"); 	// 5
    addstring(dest_list, "sorcerer"); 	// 6


### PR DESCRIPTION
The medallion dil code uses a throwback to the 90s Udgaard Mages guild.  Corrected the guild destination list in the code to allow "return conjurer" to work.  Tested working in non-prod.