### PR TITLE
Fixed Paladin Flametongue Replacement Quest

### DIFF
--- a/vme/zone/paladin_guild.zon
+++ b/vme/zone/paladin_guild.zon
@@ -938,7 +938,7 @@ or ((pc.level < 25)and
 or ((pc.level < 35)and
 (gift.nameidx $= "black_hammer")and(gift.zoneidx $= "citadel"))
 or ((pc.level < 51)and
-(gift.nameidx $= "sword_darkness")and(gift.zoneidx $= "keep")))
+(gift.nameidx $= "sword_dark")and(gift.zoneidx $= "keep")))
         {
 exec("say Ahhh... Excellent. Your courage failed you not.", self);pause;
 exec("say Now take this Flame Tongue, and use it wisely. "+


### PR DESCRIPTION
The required item from Urgnak's Champion Duerenor is called "sword_dark@keep".  The paladin replacement quest required sword_darkness@keep, which does not exist.  I have adjusted the replacement quest accordingly so that it can be completed.