### PR TITLE
Fixed Missing Extern Call in Rogue Quest

### DIFF
--- a/vme/zone/gremlin.zon
+++ b/vme/zone/gremlin.zon
@@ -237,6 +237,9 @@ dilend
 
 
 dilbegin rogue_request();
+external
+   extraptr qstSetDone@quests(qname : string, pc : unitptr);
+
 var
   pc: unitptr;
   exdp: extraptr;


### PR DESCRIPTION
When we closed the Rogue quest with qstSetDone(), the external reference was missing, causing a compile-time failure.  This fix corrects that issue.