### PR TITLE
Minor Improvement to Controlled Teleport

### DIFF
--- a/vme/zone/spells.zon
+++ b/vme/zone/spells.zon
@@ -13056,12 +13056,19 @@ code
   teleme := may_tele_away@function(self);
   teletgt := may_tele_away@function(room);
 
- if((teleme == FALSE) or (teletgt == FALSE))
+ if((teleme == FALSE))
+ {
+    act("It seems that you can't teleport from here.",
+          A_ALWAYS, self, null, null, TO_CHAR);
+    quit;
+ }
+  
+ if((teletgt == FALSE))
  {
     act("It seems that you can't teleport there.",
           A_ALWAYS, self, null, null, TO_CHAR);
     quit;
-  }
+ }
 
 if (self.type==UNIT_ST_PC)
 if (not(paycheck(self,room))){


### PR DESCRIPTION
Added a conditional to reveal to the player whether the problem with teleporting is with the room they are in, or with the room they are trying to teleport to.

It will now say: "It seems that you can't teleport from here."  If the local room is NO_TELE, rather than "It seems that you can't teleport there."