### PR TITLE
Rebate 15 MP When Teleport is Blocked by NO_TELE Flags

### DIFF
--- a/vme/zone/spells.zon
+++ b/vme/zone/spells.zon
@@ -13060,6 +13060,9 @@ code
  {
     act("It seems that you can't teleport from here.",
           A_ALWAYS, self, null, null, TO_CHAR);
+    if(self.type==UNIT_ST_PC) {
+       self.mana := self.mana + 15; // Mana Rebate on Fail
+    }
     quit;
  }
   
@@ -13067,6 +13070,9 @@ code
  {
     act("It seems that you can't teleport there.",
           A_ALWAYS, self, null, null, TO_CHAR);
+    if(self.type==UNIT_ST_PC) {
+       self.mana := self.mana + 15; // Mana Rebate on Fail
+    }
     quit;
  }
 


### PR DESCRIPTION
There isn't a mechanism to selectively charge the PC mana whether a spell succeeds or fails, so just rebating the activator 15 points if they happen to be a PC and fail the spell due to NO_TELE flags.