### PR TITLE
Feature: Player corpses auto-recall after some time, gated by quest.

### DIFF
--- a/vme/zone/death.zon
+++ b/vme/zone/death.zon
@@ -20,7 +20,7 @@ creators {"whistler"}
 #define CORPSE_EXTRA  "$CORPSE_EXTRA"
 #define CORPSE_FILE  "$CORPSE_FILE"
 #define CORPSE_TIME  "$CORPSE_TIME"
-
+#define CORPSE_HOMETOWN "$CORPSE_HOMETOWN"
 
 %dil
 
@@ -379,18 +379,26 @@ dilend
 //
 dilbegin recall rot_corpse();
 var
-	n : integer; /*amount of hours since created*/
+   n : integer; /*amount of hours since created*/
    i : integer;
    s : string;
+   corpse_room : unitptr;
 code
 {
    heartbeat:=PULSE_SEC;
    pause; // IMPORTANT. OTHERWISE THE VALUES WONT GET SET because the code will run on load()
    pause;
 
-   if (self.value[2] == 1)
+   if (self.value[2] == 1) // corpse is a player corpse
    {
-      i := 143200; // ~40 hours
+     if (self.extra.[CORPSE_HOMETOWN] != null)
+     {
+       i := 3600; // roughly 1hr plus 15m below before potential player corpse recall
+     }
+     else
+     {
+       i := 143200; // ~40 hours
+     }
       if (self.inside == null) 
          s := " empty ";
       else
@@ -410,7 +418,7 @@ code
       goto quickmag;
 
    if ((realtime-n) > i)
-	{
+   {
       :quickmag:
       if (self.value[2] == 1)
       {
@@ -430,16 +438,34 @@ code
       pause;
 
       if (not (isset(self.flags, UNIT_FL_BURIED)))
-         act("You notice some maggots crawling around on $1n", A_SOMEONE,self,null,null,TO_ALL);
+         act("You notice some maggots crawling around on $1n.", A_SOMEONE,self,null,null,TO_ALL);
       pause;
 
-      if (not (isset(self.flags, UNIT_FL_BURIED)))
-         act("A quivering horde of maggots consume $1n.", A_HIDEINV, self, null,null,TO_ALL);
+      if ((self.value[2] == 1) and (self.extra.[CORPSE_HOMETOWN] != null) and (self.inside != null))
+      {
+        act("$1n and everything in it dissolve into magical dust, floating away into the air.", A_HIDEINV, self, null, null, TO_ALL);
+        corpse_room := findroom(self.extra.[CORPSE_HOMETOWN].descr);
+        if (corpse_room == null)
+        {
+          corpse_room := findroom("temple@udgaard");
+        }
+        link (self, corpse_room);
+        act("The ashes of a body float down from the sky and form into $1n.", A_HIDEINV, self, null, null, TO_ALL);
+        log("Rescued " + self.name + " instead of destroying it.");
+        i := dildestroy("rot_corpse@death", self);
+        return;
+      }
+      else
+      {
+         if (not (isset(self.flags, UNIT_FL_BURIED)))
+            act("A quivering horde of maggots consume $1n.", A_HIDEINV, self, null,null,TO_ALL);
 
-      if (self.extra.[CORPSE_FILE] != null)
-         i := delunit(self.extra.[CORPSE_FILE].descr);
-      destroy (self);
-	}
+         if (self.extra.[CORPSE_FILE] != null)
+            i := delunit(self.extra.[CORPSE_FILE].descr);
+
+         destroy (self);
+      }
+   }
    goto start;
 
 }
@@ -713,7 +739,7 @@ dilend
 /* Corpse data is as follows:
  *   corpse.baseweight and corpse.weight set to self's baseweight
  *   corpse.height set to char's height
- *   value[2] is 0 if PC 1 if NPC
+ *   value[2] is 1 if PC 0 if NPC
  *   value[3] is the char's level
  *   value[4] is the char's race
  *   "$living_sym" in corpse.extra == self.symname of pc/npc.
@@ -819,6 +845,11 @@ code
    if (self.type==UNIT_ST_PC)
    {
       corpseroom := findcrproom(self);
+
+     if ("Soul Anchor Request Complete" in self.quests)
+     {
+         addextra(crp.extra, {CORPSE_HOMETOWN}, self.hometown);
+     }
       addextra(crp.extra, {CORPSE_EXTRA}, corpseroom);
 
       addextra(crp.extra, {CORPSE_FILE}, "corpse_"+self.name+"."+itoa(rltime));

--- a/vme/zone/gremlin.zon
+++ b/vme/zone/gremlin.zon
@@ -36,6 +36,10 @@ END HEADER*/
 #define EXPLORE_ONGOING  "Seeking Bernhard"
 #define EXPLORE_COMPLETE "Seeking Bernhard Complete"
 
+#define SOUL_ANCHOR_QUEST     "Soul Anchor Request"
+#define SOUL_ANCHOR_ONGOING   "Soul Anchor Request Ongoing"
+#define SOUL_ANCHOR_COMPLETE  "Soul Anchor Request Complete"
+
 /* ================================================================== */
 /*                                ZONE                                */
 /* ================================================================== */
@@ -660,6 +664,191 @@ code
 }
 dilend // END boldin_request
 
+dilbegin soul_anchor_qst();
+external
+  extraptr qstSetDone@quests(qname : string, pc : unitptr);
+  unitptr qstWaitDone@quests(qname : string, pc : unitptr,
+                             sl : stringlist, xp : integer,
+                             gold : integer, itemsl : stringlist);
+  extraptr qstAssign@quests(qname : string, pc : unitptr, sl : stringlist, qdescr : string);
+var
+  item: unitptr;
+  pc: unitptr;
+  exdp: extraptr;
+  mypc: unitptr;
+
+code
+{
+  heartbeat := PULSE_SEC * 3;
+
+  :start:
+
+    wait(SFB_DONE, (activator.type == UNIT_ST_PC) and (not (SOUL_ANCHOR_COMPLETE in activator.quests)));
+    pc := activator;
+
+    if (SOUL_ANCHOR_COMPLETE in pc.quests)
+    {
+      goto start;
+    }
+
+    if (SOUL_ANCHOR_ONGOING in pc.quests)
+    {
+      goto soul_anchor_ongoing;
+    }
+
+    wait(SFB_DONE,(activator.type == UNIT_ST_PC) and command("smile"));
+
+    pc := activator;
+    secure(pc, lostpc);
+
+    pause;
+    exec("emote sees your smile and cautiously wanders over.", self);
+    pause;
+    exec("say Hello, adventurer.", self);
+    pause;
+    exec("emote looks you over appraisingly.", self);
+    pause;
+    exec("say You have a strong spirit, I think.", self);
+    pause;
+    exec("say One which could withstand being separated from its body! To die and live again!", self);
+    pause;
+    exec("cackle", self);
+    pause;
+    exec("say But...", self);
+    pause;
+    exec("say If you reincarnate, it could be difficult to find your old body.", self);
+    pause;
+    exec("say Of course, the easiest thing to do would be to simply go find it.", self);
+    pause;
+    exec("say But your corpse could wind up in the most inconvient locations!", self);
+    pause;
+    exec("emote mutters something about giant ants.", self);
+    pause;
+    exec("say So I've developed a solution!", self);
+    pause;
+    exec("say A way to anchor your body to your soul, allowing it to come back to you after some time.", self);
+    pause;
+    exec("say Would you be interested in this technique?", self);
+    pause;
+    exec("say If so, nod.", self);
+
+    goto accept_explore;
+
+  :accept_explore:
+    wait(SFB_DONE, activator.type == UNIT_ST_PC);
+    pc := activator;
+    if (command("nod"))
+    {
+      goto anchor_accepted;
+    }
+    else if (command("shake"))
+    {
+      goto no_quest;
+    }
+    else
+    {
+      act("<div class='whisper'>The shaman says '<div class='hint'>Nod</div> if you agree to help, <div class='hint'>shake</div> your head otherwise.'</div>",A_SOMEONE, pc, null, null, TO_CHAR);
+      goto accept_explore;
+    }
+
+  :no_quest:
+
+    exec("say Too scared, I suppose.", self);
+    exec("shrug", self);
+    unsecure(pc);
+    goto start;
+
+  :anchor_accepted:
+    exec("grin", self);
+    pause;
+    exec("say Very good.", self);
+    pause;
+    exec("say To form the anchor, I need the life force of someone powerful.", self);
+    pause;
+    exec("say Not you or me, of course!", self);
+    pause;
+    exec("emote coughs awkwardly.", self);
+    pause;
+    exec("say One of the grumpkins, Gaflaw, is stronger than all the rest.", self);
+    pause;
+    exec("say Bring me something with his life force!", self);
+    pause;
+    exec("drool", self);
+
+    // note to self: there's explicitly-set heartbeat before this kicks in
+    qstAssign@quests(SOUL_ANCHOR_QUEST, pc,
+                     {"This string doesn't seem to be used?"},
+                     "seeking Gaflaw's life");
+    exec("say Go now, and return when you have what I need.", self);
+
+    unsecure(pc);
+    goto start;
+
+  :soul_anchor_ongoing:
+
+    // Due to this being very simple and issues with qstWaitDone / qstItemsWanted,
+    // it's just re-implemented here.
+    wait(SFB_DONE, command("give") and (target == self));
+
+    pc := activator;
+    item := medium;
+
+    secure(pc, lostpc);
+
+    if (item.symname == "heart@gremlin")
+    {
+      destroy(item);
+      exec("grin", self);
+      pause;
+      exec("emote beckons you over to the corner of the room.", self);
+      pause;
+      exec("emote holds the heart aloft in one hand while touching your head with the other.", self);
+      pause;
+      act("You feel a sudden shock! The heart disappears in a flash of light!", A_SOMEONE, pc, null, null, TO_CHAR);
+      pause;
+      exec("say It is done.", self);
+      pause;
+      exec("say Your body is linked with your soul!", self);
+      pause;
+      exec("say When you die, after some time, your corpse will return to where you resurrect.", self);
+      pause;
+      if (pc.hometown == "temple@udgaard")
+      {
+        exec("emote mutters 'Probably that temple in udgaard...'", self);
+      }
+      else
+      {
+        exec("emote mutters 'Probably your clan house...'", self);
+      }
+      pause;
+      exec("say But remember, it will take some time! It will be faster to find your corpse on your own.", self);
+      pause;
+      exec("say Now, go forth and die freely!", self);
+      pause;
+      exec("wave $1n", self);
+
+      // settle rewards
+      subextra(pc.quests, SOUL_ANCHOR_ONGOING);
+      addextra(pc.quests, {SOUL_ANCHOR_COMPLETE}, "");
+
+      experience(1000, pc);
+      sendtext("You earned 1000 experience.<br/>", pc);
+
+    }
+    else
+    {
+      exec("say This isn't the right thing.", self);
+      link(medium, activator);
+    }
+
+    unsecure(pc);
+    goto start;
+
+  :lostpc:
+    exec("sigh", self);
+    goto start;
+}
+dilend // END soul_anchor_quest
 
 dilbegin barnham_request();
 external
@@ -1651,6 +1840,19 @@ dilcopy qstItemsWanted@quests(BOLDIN_WATER, {"water_barrel@gremlin"}, {"fluidche
 
 end
 
+anchorman
+names {"shaman", "gremlin"}
+title "the shaman"
+descr "A gremlin in dark robes stands in the corner."
+extra {}
+"Small and ugly like the rest of the gremlins, this one looks a little less hostile than the rest. It briefly makes eye contact with you with a questioning expression on its face before looking away. Perhaps a smile would show you mean no harm?"
+M_AVG_GOBLIN(30, SEX_FEMALE)
+alignment -500
+money 2 COPPER_PIECE
+dilcopy soul_anchor_qst@gremlin();
+
+end
+
 barnham
 names {"barnham","man"}
 title "Farmer Barnham"
@@ -2173,6 +2375,17 @@ dilcopy mana_drain@sorcerer();
 rent 100 IRON_PIECE
 end
 
+heart
+names {"gaflaw's heart", "heart"}
+title "a beating heart"
+descr "A heart beats here on the ground."
+extra {} "A steaming heart, fresh and full of life. It wiggles slightly, trying to beat even outside the body."
+manipulate {MANIPULATE_TAKE}
+FOOD_DEF(12, 0)
+weight 2
+cost 1 IRON_PIECE
+end
+
 %reset
 
 load carrot_sign into fn_02 max 1
@@ -2383,6 +2596,7 @@ load gaflaw into fcave_12 max 1
 {
    equip gaflaw_club position WEAR_WIELD
    equip adv_helm position WEAR_HEAD
+   load heart
 }
 load gguard into fcave_12 max 2
 {
@@ -2414,6 +2628,8 @@ load adv_chest into farm_attic local 1
 load heal_jug into cave_01 local 3
 
 load sventer into dock1@torsbay max 1
+
+load anchorman into fcave_11@gremlin max 1
 
 // doors
 

--- a/vme/zone/quests.zon
+++ b/vme/zone/quests.zon
@@ -336,7 +336,6 @@ code
 dilend
 
 
-
 // Add this to a quest NPC that's waiting to "get items" from a player.
 // The items received will be destroyed, and incorrect items given back.
 //
@@ -568,10 +567,10 @@ code
    u := null;
 
    :start:
-   if ((qname + " Complete") in activator.quests)
+   if ((qname + " Complete") in pc.quests)
      return(u);
 
-   exdp := (qname + " Ongoing") in activator.quests;
+   exdp := (qname + " Ongoing") in pc.quests;
 
    if (not exdp)
       return(u);


### PR DESCRIPTION
@chrisspanton as we discussed a few days ago -

Sometimes exploring goes wrong and you die.  While it's usually fine, occasionally this leads to player stress around exploring dangerous areas because corpse retrieval can require assistance from other players or admins. To address this, this PR introduces a new feature for automatic corpse retrieval gated behind a quest. Players who have not completed the quest (and non-player corpses) are unchanged.

Quest:
Content: In the gremlin zone, there is a new NPC who asks you to fetch an item from Gaflaw (the large gremlin).
Rationale: The feature should not be enabled on 'throwaway' characters or others who play only temporarily and whose corpses do not need to be maintained. However, corpse retrieval assistance is often most necessary at low-mid levels. As such, the quest is easy to do but it's likely the player is vaguely committed to the game.

Feature:
Content: Players who have the quest completion flag have their corpses marked with the player's hometown (place where they will resurrect). Instead of their corpses taking the usual ~40 hours to decompose, after ~75 minutes their corpse will transport to their hometown and remain there without decomposing. Empty corpses will decompose as usual (as there is no reason to keep them).
Rationale: It should always be more appealing to go fetch the corpse yourself - thus the 75-minute delay encouraging players to do things the old-fashioned way. If you can't get your body back, it should be a sign to take a break and try again after a while.

Other:
I also changed two instances of `activator` in `qstWaitDone` to be the provided `pc` because the dil didn't work for me after a wait without it. I don't think this affects anything else.