### PR TITLE
allow give to use the full string provided, while not breaking previous behavior

### DIFF
--- a/vme/zone/baseget.zon
+++ b/vme/zone/baseget.zon
@@ -1557,16 +1557,11 @@ code
          cnt := 1;
 }
 
+   temp := arg;
 
 :loop2:
 
    toitem := findunit(self, temp, FIND_UNIT_SURRO, null);
-
-   if (toitem == null)
-   {
-      temp := arg;
-      toitem := findunit(self, temp, FIND_UNIT_SURRO, null);
-   }
 
    if ((toitem) and (not visible(self, toitem)))
    {

--- a/vme/zone/baseget.zon
+++ b/vme/zone/baseget.zon
@@ -1562,6 +1562,12 @@ code
 
    toitem := findunit(self, temp, FIND_UNIT_SURRO, null);
 
+   if (toitem == null)
+   {
+      temp := arg;
+      toitem := findunit(self, temp, FIND_UNIT_SURRO, null);
+   }
+
    if ((toitem) and (not visible(self, toitem)))
    {
       cnt := cnt + 1;


### PR DESCRIPTION
The `give` command (and a couple others, when looking around) only allows a single word target. It seems to be a common pattern to have commands interpret only the first word of the argument:

```
   temp := arg;
   temp := getword(temp);
```

I'm not sure why that is - maybe it's helpful to allow garbage suffixes to be applied to targets? Regardless, this adds a branch so that if the initial 'single-word' target doesn't find anything, it tries again with the whole "argument" portion of the command.