### PR TITLE
Add CMakeLists.txt for project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.idea/
+cmake-build-debug/
+cmake-build-default/
+cmake-build-minsizerel/
+cmake-build-release/
+cmake-build-relwithdebinfo/
+.*.swp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.20)
+project(DikuMUD3)
+
+find_package(BISON)
+find_package(FLEX)
+find_package(Boost COMPONENTS unit_test_framework filesystem regex system REQUIRED)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-fpermissive -fdiagnostics-color=always -Wno-register")
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/vme/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/vme/bin)
+
+add_compile_definitions(LINUX POSIX)
+
+include_directories(vme/src)
+link_directories(${CMAKE_SOURCE_DIR}/vme/bin)
+
+add_custom_target(everything)
+add_dependencies(everything vme vmc defcomp mplex pp)
+
+add_subdirectory(vme)
+add_subdirectory(vme/src)
+add_subdirectory(vme/src/defcomp)
+add_subdirectory(vme/src/mplex2)
+add_subdirectory(vme/src/pp)
+add_subdirectory(vme/src/vmc)
+
+add_subdirectory(unit_tests)

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -1,0 +1,37 @@
+# Building with cmake from command line
+
+Pre-requisites:
+   * cmake
+   * optional ninja build system (Fedora: `sudo dnf install ninja-build`)
+
+The examples below will use the ninja build system but if you want to use gnu make change `-G Ninja` to `-G "Unix Makefiles"` in the below commands. Then rather than executing `ninja` run `make` instead.
+
+### Ninja
+Ninja is a lot like make - so you can build specific targets eg `ninja pp`. The equivalent of `make all` is just `ninja` as everything is the default.
+
+## Building Binaries
+***Note this replaces Step 1 portion of README.md***
+
+All these are run from top level of project (eg DikiMud3) 
+
+#### List of built-in build types
+* Debug
+* Release
+* RelWithDebInfo
+* MinSizeRel
+
+### Build Debug version
+From top level of project
+
+    mkdir cmake-build-debug
+    cd cmake-build-debug
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ ..
+    ninja
+
+### Build Release version
+From top level of project
+
+    mkdir cmake-build-release
+    cd cmake-build-release
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ ..
+    ninja

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,0 +1,43 @@
+set (Boost_USE_STATIC_LIBS OFF)
+
+include_directories (${Boost_INCLUDE_DIRS})
+
+set(VME vme)
+set(VMC vmc)
+set(PP pp)
+set(DEFCOMP defcomp)
+set(MPLEX mplex)
+
+add_custom_target(all_unit_tests)
+add_dependencies(vme ${VME}_unit_tests ${VMC}_unit_tests ${PP}_unit_tests ${DEFCOMP}_unit_tests ${MPLEX}_unit_tests)
+
+
+############################### VME ######################################
+add_executable(${VME}_unit_tests ${VME}_main.cpp)
+target_compile_definitions(${VME}_unit_tests PUBLIC ${COMPILE_DEFINITIONS} DMSERVER)
+target_link_libraries(${VME}_unit_tests ${Boost_LIBRARIES} ${VME}_objs)
+
+############################### VMC ######################################
+add_executable(${VMC}_unit_tests vmc_main.cpp)
+target_compile_definitions(${VMC}_unit_tests PUBLIC ${COMPILE_DEFINITIONS} VMC_SRC VMC MUD_DEBUG)
+target_link_libraries(${VMC}_unit_tests
+        ${Boost_LIBRARIES}
+        ${VMC}_objs
+        ${VMC}_dep_objs
+        ${PP}_objs
+        )
+
+############################### PP #######################################
+add_executable(${PP}_unit_tests ${PP}_main.cpp)
+target_link_libraries (${PP}_unit_tests ${Boost_LIBRARIES} ${PP}_objs)
+
+############################### MPLEX ####################################
+add_executable(${MPLEX}_unit_tests ${MPLEX}_main.cpp)
+target_link_libraries(${MPLEX}_unit_tests
+        ${Boost_LIBRARIES}
+        ${MPLEX}_objs
+        ${MPLEX}_dep_objs)
+
+############################### DEFCOMP ##@###############################
+add_executable(${DEFCOMP}_unit_tests ${DEFCOMP}_main.cpp)
+target_link_libraries(${DEFCOMP}_unit_tests ${Boost_LIBRARIES})

--- a/unit_tests/defcomp_main.cpp
+++ b/unit_tests/defcomp_main.cpp
@@ -1,0 +1,9 @@
+#define BOOST_TEST_MODULE "DEFCOMP Unit Tests"
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(SampleTest)
+{
+   BOOST_CHECK(true == true);
+}

--- a/unit_tests/mplex_main.cpp
+++ b/unit_tests/mplex_main.cpp
@@ -1,0 +1,9 @@
+#define BOOST_TEST_MODULE "MPlex Unit Tests"
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(SampleTest)
+{
+   BOOST_CHECK(true == true);
+}

--- a/unit_tests/pp_main.cpp
+++ b/unit_tests/pp_main.cpp
@@ -1,0 +1,9 @@
+#define BOOST_TEST_MODULE "PP Unit Tests"
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(SampleTest)
+{
+   BOOST_CHECK(true == true);
+}

--- a/unit_tests/vmc_main.cpp
+++ b/unit_tests/vmc_main.cpp
@@ -1,0 +1,9 @@
+#define BOOST_TEST_MODULE "VMC Unit Tests"
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(SampleTest)
+{
+   BOOST_CHECK(true == true);
+}

--- a/unit_tests/vme_main.cpp
+++ b/unit_tests/vme_main.cpp
@@ -1,0 +1,9 @@
+#define BOOST_TEST_MODULE "VME Unit Tests"
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(SampleTest)
+{
+   BOOST_CHECK(true == true);
+}

--- a/vme/CMakeLists.txt
+++ b/vme/CMakeLists.txt
@@ -1,0 +1,1 @@
+# this file is internationally empty

--- a/vme/bin/.gitignore
+++ b/vme/bin/.gitignore
@@ -8,3 +8,14 @@ pp
 fixhtml
 discord.token
 __pycache__
+libvme_objs.a
+libmplex_dep_objs.a
+libmplex_objs.a
+libpp_objs.a
+libvmc_dep_objs.a
+libvmc_objs.a
+defcomp_unit_tests
+mplex_unit_tests
+pp_unit_tests
+vmc_unit_tests
+vme_unit_tests

--- a/vme/src/CMakeLists.txt
+++ b/vme/src/CMakeLists.txt
@@ -1,0 +1,111 @@
+set(VME_SRCS
+        account.cpp account.h
+        act.h
+        act_change.cpp
+        act_color.cpp
+        act_info.cpp
+        act_movement.cpp
+        act_offensive.cpp
+        act_other.cpp
+        act_skills.cpp
+        act_wizard.cpp
+        act_wstat.cpp
+        affect.cpp affect.h
+        affectdil.h
+        apf_affect.cpp
+        badnames.cpp badnames.h
+        ban.cpp ban.h
+        bank.cpp
+        base.h
+        bytestring.cpp bytestring.h
+        cmdload.cpp cmdload.h
+        color.cpp color.h
+        combat.cpp combat.h
+        comm.cpp comm.h
+        common.cpp common.h
+        config.cpp config.h
+        constants.cpp constants.h
+        convert.cpp
+        db.cpp db.h
+        db_file.cpp db_file.h
+        db_utils.cpp
+        dbfind.cpp dbfind.h
+        destruct.cpp destruct.h
+        dictionary.cpp
+        dil.h
+        dilexp.cpp dilexp.h
+        dilfld.cpp
+        dilinst.cpp dilinst.h
+        dilrun.cpp dilrun.h
+        dilshare.cpp
+        dilsup.cpp dilsup.h
+        eliza.cpp
+        essential.h
+        event.cpp event.h
+        experience.cpp
+        extra.cpp extra.h
+        fight.cpp fight.h
+        files.cpp files.h
+        guild.cpp guild.h
+        guilddef.h
+        handler.cpp handler.h
+        hook.cpp hook.h
+        hookmud.cpp hookmud.h
+        interpreter.cpp interpreter.h
+        intlist.cpp intlist.h
+        justice.cpp justice.h
+        limits.cpp
+        liquid.h
+        magic.cpp magic.h
+        main.h
+        membug.cpp membug.h
+        mobact.cpp
+        modify.cpp modify.h
+        money.cpp money.h
+        movement.h
+        namelist.cpp namelist.h
+        nanny.cpp
+        nice.cpp
+        path.cpp path.h
+        pcsave.cpp
+        pipe.cpp
+        protocol.cpp protocol.h
+        queue.cpp queue.h
+        reception.cpp
+        sector.cpp sector.h
+        signals.cpp
+        skills.cpp skills.h
+        slime.cpp
+        spec_assign.cpp spec_assign.h
+        spec_procs.cpp
+        spell_parser.cpp
+        spelldef.h
+        spells.h
+        str_parse.cpp str_parse.h
+        structs.cpp structs.h
+        system.cpp system.h
+        teach.cpp
+        textutil.cpp textutil.h
+        tif_affect.cpp
+        trie.cpp trie.h
+        unitfind.cpp unitfind.h
+        utility.cpp utility.h
+        utils.h
+        values.h
+        vme.h
+        vmelimits.h
+        weather.cpp weather.h
+        wmacros.h
+        zon_basis.cpp
+        zon_wiz.cpp
+        zone_reset.cpp
+        )
+
+add_compile_definitions(DMSERVER)
+
+# Add all sources to a library file so we can link with subject projects and test suites
+add_library(vme_objs STATIC ${VME_SRCS})
+
+add_executable(vme main.cpp)
+
+target_link_libraries(vme vme_objs crypt Boost::filesystem)

--- a/vme/src/defcomp/CMakeLists.txt
+++ b/vme/src/defcomp/CMakeLists.txt
@@ -1,0 +1,7 @@
+project(defcomp)
+
+set(DC_SRCS
+        defcomp.cpp
+        )
+
+add_executable(defcomp ${DC_SRCS})

--- a/vme/src/mplex2/CMakeLists.txt
+++ b/vme/src/mplex2/CMakeLists.txt
@@ -1,0 +1,38 @@
+project(mplex2)
+
+set(MPLEX_SRCS
+        ClientConnector.cpp ClientConnector.h
+        MUDConnector.cpp MUDConnector.h
+        echo_server.cpp
+        mplex.cpp mplex.h
+        network.cpp network.h
+        telnet.h
+        translate.cpp translate.h
+        ttydef.h
+        )
+
+# Source files from other parts to link with mplex
+set(MPLEX_DEP_SRCS
+        ../bytestring.cpp ../bytestring.h
+        ../color.cpp ../color.h
+        ../hook.cpp ../hook.h
+        ../membug.cpp ../membug.h
+        ../protocol.cpp ../protocol.h
+        ../queue.cpp ../queue.h
+        ../textutil.cpp ../textutil.h
+        ../utility.cpp ../utility.h
+        )
+include_directories(.)
+
+add_executable(mplex mplex.cpp)
+
+# Add all sources to a library file so we can link with subject projects and test suites
+add_library(mplex_objs STATIC ${MPLEX_SRCS})
+
+#Add all other project sources to a library file so we can link with subject projects and test suites
+add_library(mplex_dep_objs STATIC ${MPLEX_DEP_SRCS})
+
+target_link_libraries(mplex
+        mplex_objs
+        mplex_dep_objs
+        )

--- a/vme/src/pp/CMakeLists.txt
+++ b/vme/src/pp/CMakeLists.txt
@@ -1,0 +1,21 @@
+project(pp)
+
+set(PP_SRCS
+        main.cpp
+        pp.h
+        pp1.cpp
+        pp2.cpp
+        pp3.cpp
+        pp4.cpp
+        pp5.cpp
+        pp6.cpp
+        pp7.cpp
+        pp8.cpp
+        )
+
+add_executable(pp main.cpp)
+
+# Add all sources to a library file so we can link with subject projects and test suites
+add_library(pp_objs STATIC ${PP_SRCS})
+
+target_link_libraries(pp pp_objs)

--- a/vme/src/vmc/CMakeLists.txt
+++ b/vme/src/vmc/CMakeLists.txt
@@ -1,0 +1,78 @@
+project(vmc)
+
+set(VMC_SRCS
+        dilpar.h
+        dilshare.cpp
+        diltok.h
+        vmc.cpp vmc.h
+        vmc_process.cpp
+        vmctok.h
+        )
+
+# Source files from other parts to link with vme
+set(VMC_DEP_SRCS
+        ../bytestring.cpp ../bytestring.h
+        ../color.cpp ../color.h
+        ../common.cpp ../common.h
+        ../db_file.cpp ../db_file.h
+        ../destruct.cpp ../destruct.h
+        ../extra.cpp ../extra.h
+        ../files.cpp ../files.h
+        ../intlist.cpp ../intlist.h
+        ../membug.cpp ../membug.h
+        ../money.cpp ../money.h
+        ../namelist.cpp ../namelist.h
+        ../spec_assign.cpp ../spec_assign.h
+        ../structs.cpp ../structs.h
+        ../textutil.cpp ../textutil.h
+        ../utility.cpp ../utility.h
+        )
+
+include_directories(.)
+
+BISON_TARGET(vmcpar vmcpar.y
+        ${CMAKE_CURRENT_BINARY_DIR}/tmp_vmcpar.cpp
+        COMPILE_FLAGS "--debug -y -d -v"
+        DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/tmp_vmcpar.h
+        REPORT_FILE ${CMAKE_CURRENT_BINARY_DIR}/tmp_vmcpar.output
+        )
+FLEX_TARGET(vmclex
+        vmclex.l
+        ${CMAKE_CURRENT_BINARY_DIR}/tmp_vmclex.cpp
+        )
+ADD_FLEX_BISON_DEPENDENCY(vmclex vmcpar)
+
+BISON_TARGET(dilpar dilpar.y
+        ${CMAKE_CURRENT_BINARY_DIR}/tmp_dilpar.cpp
+        COMPILE_FLAGS "--debug -d -v -pdil"
+        DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/tmp_dilpar.h
+        REPORT_FILE ${CMAKE_CURRENT_BINARY_DIR}/tmp_dilpar.output
+        )
+FLEX_TARGET(dillex
+        dillex.l
+        ${CMAKE_CURRENT_BINARY_DIR}/tmp_dillex.cpp
+        COMPILE_FLAGS "-Pdil"
+        )
+ADD_FLEX_BISON_DEPENDENCY(dillex dilpar)
+
+add_compile_definitions(VMC_SRC VMC MUD_DEBUG)
+
+add_executable(vmc vmc.cpp)
+
+add_library(vmc_objs STATIC
+        ${VMC_SRCS}
+        ${BISON_dilpar_OUTPUTS}
+        ${FLEX_dillex_OUTPUTS}
+        ${BISON_vmcpar_OUTPUTS}
+        ${FLEX_vmclex_OUTPUTS}
+        )
+
+#Add all other project sources to a library file so we can link with subject projects and test suites
+add_library(vmc_dep_objs STATIC ${VMC_DEP_SRCS})
+
+target_link_libraries(vmc
+        vmc_objs
+        pp_objs
+        vmc_dep_objs
+        ${FLEX_LIBRARIES}
+        )


### PR DESCRIPTION
Added CMakeLists.txt  mainly for CLion IDE but can be used to compile
the project as well.

Created skeleton layout for unit tests.