### PR TITLE
Truncate messages to prevent buffer overflows

### DIFF
--- a/vme/src/handler.cpp
+++ b/vme/src/handler.cpp
@@ -1053,20 +1053,14 @@ class extra_descr_data *quest_add(class unit_data *ch, const char *name, const c
 /* void szonelog(char *zonename, const char *fmt, ...) */
 void szonelog(class zone_type *zone, const char *fmt, ...)
 {
-    char name[256];
-    char buf[MAX_STRING_LENGTH], buf2[MAX_STRING_LENGTH + 512];
+    char name[256]{};
+    char buf[MAX_STRING_LENGTH]{};
+    char buf2[MAX_STRING_LENGTH + 512]{};
     va_list args;
     FILE *f;
 
-    time_t now = time(0);
-    char *tmstr = ctime(&now);
-
-    tmstr[strlen(tmstr) - 1] = '\0';
-
     va_start(args, fmt);
-
     vsnprintf(buf, MAX_STRING_LENGTH - 51, fmt, args);
-    buf[MAX_STRING_LENGTH - 51] = 0;
     va_end(args);
 
     if (zone == NULL)
@@ -1075,13 +1069,22 @@ void szonelog(class zone_type *zone, const char *fmt, ...)
         return;
     }
 
-    sprintf(buf2, "%s/%s", zone->name, buf);
+    snprintf(buf2, sizeof(buf2), "%s/%s", zone->name, buf);
     slog(LOG_ALL, 0, buf2);
 
-    sprintf(name, "%s%s.err", g_cServerConfig.m_zondir, zone->filename);
+    snprintf(name, sizeof(name), "%s%s.err", g_cServerConfig.m_zondir, zone->filename);
 
     if ((f = fopen_cache(name, "a")) == NULL)
-        slog(LOG_ALL, 0, "Unable to append to zonelog '%s'", name);
+    {
+       slog(LOG_ALL, 0, "Unable to append to zonelog '%s'", name);
+    }
     else
-        fprintf(f, "%s :: %s\n", tmstr, buf);
+    {
+       time_t now = time(0);
+       char *tmstr = ctime(&now);
+
+       tmstr[strlen(tmstr) - 1] = '\0';
+
+       fprintf(f, "%s :: %s\n", tmstr, buf);
+    }
 }

--- a/vme/src/utility.cpp
+++ b/vme/src/utility.cpp
@@ -98,26 +98,34 @@ class log_buffer log_buf[MAXLOG];
 /* writes a string to the log */
 void slog(enum log_level level, ubit8 wizinv_level, const char *fmt, ...)
 {
-   static ubit8 idx = 0;
+   static ubit8  idx      = 0;
    static ubit32 log_size = 0;
-   char buf[MAX_STRING_LENGTH], *t;
-   va_list args;
+   char          buf[MAX_STRING_LENGTH]{};
+   char         *t                     = buf;
+   size_t        buffer_size_remaining = MAX_STRING_LENGTH;
+   va_list       args;
 
    time_t now = time(0);
    char *tmstr = ctime(&now);
 
    tmstr[strlen(tmstr) - 1] = '\0';
 
-   if (wizinv_level > 0)
-      sprintf(buf, "(%d) ", wizinv_level);
-   else
-      *buf = '\0';
-
-   t = buf;
-   TAIL(t);
+   if(wizinv_level > 0)
+   {
+      auto chars_printed = snprintf(buf, buffer_size_remaining, "(%d) ", wizinv_level);
+      if(chars_printed < 0 || chars_printed >= buffer_size_remaining)
+      {
+         buffer_size_remaining = 0;
+      }
+      else
+      {
+         buffer_size_remaining -= chars_printed;
+         t += chars_printed;
+      }
+   }
 
    va_start(args, fmt);
-   vsprintf(t, fmt, args);
+   vsnprintf(t, buffer_size_remaining, fmt, args);
    va_end(args);
 
    /* 5 == " :: \n";  24 == tmstr (Tue Sep 20 18:41:23 1994) */


### PR DESCRIPTION
Resovles #61 Check slog and szonelog

There definitely could be overflows.