### PR TITLE
Remove "using namespace"'s because it breaks Cent 7 compile

### DIFF
--- a/vme/src/act_color.cpp
+++ b/vme/src/act_color.cpp
@@ -133,7 +133,7 @@ void do_color(class unit_data *ch, char *aaa, const struct command_info *cmd)
 
     if (change == TRUE)
     {
-        string mystr; 
+        std::string mystr;
 
         mystr = UPC(ch)->color.change(full_name, cbuf);
         sprintf(cbuf, "Color %s changed.<br/>", mystr.c_str());

--- a/vme/src/act_info.cpp
+++ b/vme/src/act_info.cpp
@@ -92,7 +92,7 @@ void do_where(class unit_data *ch, char *aaa, const struct command_info *cmd)
     register class unit_data *i;
     class descriptor_data *d;
     char *arg = (char *)aaa;
-    string mystr;
+    std::string mystr;
     int nCount = 0;
 
     if (IS_MORTAL(ch))

--- a/vme/src/act_wstat.cpp
+++ b/vme/src/act_wstat.cpp
@@ -821,7 +821,7 @@ static void stat_extra(const class unit_data *ch, class extra_list &elist, char 
     /* MS: We used to do a TAIL here... bad idea as newspaper is VERY HUGE */
     /* This isn't nice either, but it works... */
     char *cname;
-    string str;
+    std::string str;
 
     str = "";
 
@@ -1286,7 +1286,7 @@ void do_wedit(class unit_data *ch, char *argument, const struct command_info *cm
         }
     }
 
-    string t;
+    std::string t;
 
     t = "<data type='$json'>";
     t.append(u->json());

--- a/vme/src/cmdload.cpp
+++ b/vme/src/cmdload.cpp
@@ -85,14 +85,14 @@ struct cmdload_struct cmdload[] = {
 
 void skill_dump(void)
 {
-    string str;
+    std::string str;
     char buf[MAX_STRING_LENGTH];
 
-    bool pairISCompare(const std::pair<int, string>& firstElem, const std::pair<int, string>& secondElem);
+    bool pairISCompare(const std::pair<int,std::string>& firstElem, const std::pair<int,std::string>& secondElem);
 
     for (int j = 0; j < PROFESSION_MAX; j++)
     {
-        vector< pair <int,string> > vect;
+        std::vector< std::pair <int,std::string> > vect;
 
         for (int i = 0; i < SKI_TREE_MAX; i++)
         {

--- a/vme/src/combat.cpp
+++ b/vme/src/combat.cpp
@@ -342,7 +342,7 @@ void cCombat::status(const class unit_data *god)
 {
    char buf[MAX_STRING_LENGTH];
    int i;
-   string str;
+   std::string str;
 
    sprintf(buf,
            "Combat Status of '%s':<br/>"
@@ -468,7 +468,7 @@ void stat_combat(class unit_data *god, class unit_data *u, const char *pStr)
       CHAR_COMBAT(u)->status(god);
 
 
-   string str;
+   std::string str;
    melee_bonus(u, u2, WEAR_BODY, NULL, NULL, NULL, NULL, TRUE, &str);
    send_to_char(str.c_str(), god);
    melee_bonus(u2, u, WEAR_BODY, NULL, NULL, NULL, NULL, TRUE, &str);
@@ -522,7 +522,7 @@ void stat_spell(class unit_data *god, class unit_data *u, const char *pStr)
                   int *pDef_armour_type, class unit_data **pDef_armour,
                   std::string *pStat);
 
-   string str;
+   std::string str;
    spell_bonus(u, u, u2, WEAR_BODY, i, NULL, NULL, &str);
    send_to_char(str.c_str(), god);
    spell_bonus(u2, u2, u, WEAR_BODY, i, NULL, NULL, &str);

--- a/vme/src/comm.cpp
+++ b/vme/src/comm.cpp
@@ -79,7 +79,7 @@ int cActParameter::isNull(void)
  *  user's color preferences.  You probably only want to do this for telnet users.
  *  web users can rely on the styles defined in the CSS
 */
-void substHTMLcolor(string &dest, const char *src, class color_type &color)
+void substHTMLcolor(std::string &dest, const char *src, class color_type &color)
 {
     const char *p;
 
@@ -157,7 +157,7 @@ void send_to_descriptor(const char *messg, class descriptor_data *d)
                 u = d->original;
 
             assert(IS_PC(u));
-            string dest;
+            std::string dest;
             dest.reserve(strlen(messg)*1.1);
             //char buf[strlen(messg) + 10000];
 

--- a/vme/src/convert.cpp
+++ b/vme/src/convert.cpp
@@ -101,8 +101,8 @@ convert_item(class unit_data *u, class unit_data *pc, int bList)
         if (strcmp(UNIT_FI_ZONE(u)->name, "treasure") == 0)
         {
             class extra_descr_data *ed = UNIT_EXTRA(u).m_pList;
-            std::cout << endl
-                      << UNIT_FI_NAME(u) << "@treasure" << endl;
+            std::cout << std::endl
+                      << UNIT_FI_NAME(u) << "@treasure" << std::endl;
             if (ed)
             {
                 bool found = false;
@@ -120,7 +120,7 @@ convert_item(class unit_data *u, class unit_data *pc, int bList)
                         std::cout << ed->descr.c_str() << " ";
                     }
                 }
-                std::cout << endl;
+                std::cout << std::endl;
             }
         }
 
@@ -357,7 +357,7 @@ void clist()
     struct time_info_data age(class unit_data * ch);
     struct time_info_data real_time_passed(time_t t2, time_t t1);
 
-    string ipath;
+    std::string ipath;
     /*
         std::cout << "\nEnter the full path to the root player directory for example '/home/mud/vme2.0/lib/ply' or \n<enter> for the one listed in the server.cfg file:  ";
     char cpath[1024];
@@ -390,9 +390,9 @@ void clist()
         std::cout << "\nIn directory: "
                   << full_path << "\n\n";
         fs::directory_iterator end_iter;
-        string path_end = "";
+        std::string path_end = "";
 
-        std::cout << "name;id;Level;Admin;days since login;created;birth;" << endl;
+        std::cout << "name;id;Level;Admin;days since login;created;birth;" << std::endl;
  
         for (char c = 'a'; c <= 'z'; c++)
         {
@@ -419,7 +419,7 @@ void clist()
                     {
                         ++dir_count;
                     }
-                    else if (dir_itr->path().filename().string().find(".") == string::npos)
+                    else if (dir_itr->path().filename().string().find(".") == std::string::npos)
                     {
                         ++file_count;
 
@@ -497,7 +497,7 @@ void clist()
                         else
                             std::cout << " Less than an hour";
 
-                        std::cout << "; " << endl;
+                        std::cout << "; " << std::endl;
 
                         delete temp;
                     }
@@ -526,7 +526,7 @@ void clist()
 
 void convert_file(void)
 {
-    string ipath;
+    std::string ipath;
     ipath = CONVERT_PATH;
 
     fs::path full_path(ipath);
@@ -548,7 +548,7 @@ void convert_file(void)
         std::cout << "\nIn directory: "
                   << full_path << "\n\n";
         fs::directory_iterator end_iter;
-        string path_end = "";
+        std::string path_end = "";
         for (char c = 'a'; c <= 'z'; c++)
         {
             path_end = c;
@@ -575,7 +575,7 @@ void convert_file(void)
                     {
                         ++dir_count;
                     }
-                    else if (dir_itr->path().filename().string().find(".") == string::npos)
+                    else if (dir_itr->path().filename().string().find(".") == std::string::npos)
                     {
                         ++file_count;
                         std::cout << dir_itr->path() << "\n";
@@ -585,17 +585,17 @@ void convert_file(void)
 
                         if (pc == NULL)
                         {
-                            std::cout << "Corrupt Player ERASED." << endl;
+                            std::cout << "Corrupt Player ERASED." << std::endl;
                             delete_player(temp);
                             continue;
                         }
 
                         if (ids[PC_ID(pc)])
-                            std::cout << "Duplicate ID! (" << (signed long)PC_ID(pc) << ")" << endl;
+                            std::cout << "Duplicate ID! (" << (signed long)PC_ID(pc) << ")" << std::endl;
                         else
                             ids[PC_ID(pc)] = 1;
 
-                        std::cout << UNIT_NAME(pc) << " Lvl [" << CHAR_LEVEL(pc) << "] " << (IS_MORTAL(pc) ? "   " : "ADMIN") << endl;
+                        std::cout << UNIT_NAME(pc) << " Lvl [" << CHAR_LEVEL(pc) << "] " << (IS_MORTAL(pc) ? "   " : "ADMIN") << std::endl;
 
                         std::cout.flush();
                         load_contents(temp, pc);
@@ -631,7 +631,7 @@ void convert_file(void)
 
 void cleanup(void)
 {
-    string ipath;
+    std::string ipath;
     ipath = CONVERT_PATH;
 
     fs::path full_path(ipath);
@@ -656,7 +656,7 @@ void cleanup(void)
         std::cout << "\nIn directory: "
                   << full_path << "\n\n";
         fs::directory_iterator end_iter;
-        string path_end = "";
+        std::string path_end = "";
         for (char c = 'a'; c <= 'z'; c++)
         {
             path_end = c;
@@ -683,7 +683,7 @@ void cleanup(void)
                     {
                         ++dir_count;
                     }
-                    else if (dir_itr->path().filename().string().find(".") == string::npos)
+                    else if (dir_itr->path().filename().string().find(".") == std::string::npos)
                     {
                         ++file_count;
                         std::cout << dir_itr->path() << "\n";
@@ -694,7 +694,7 @@ void cleanup(void)
 
                         if (pc == NULL)
                         {
-                            std::cout << "Corrupt Player ERASED." << endl;
+                            std::cout << "Corrupt Player ERASED." << std::endl;
                             delete_player(temp);
                             delete temp;
                             ++players_deleted;
@@ -703,7 +703,7 @@ void cleanup(void)
 
                         if (str_ccmp(temp, UNIT_NAME(pc)))
                         {
-                            std::cout << "Name in file doesn't match filename." << endl;
+                            std::cout << "Name in file doesn't match filename." << std::endl;
                             convert_free_unit(pc);
                             delete_player(temp);
                             ++players_deleted;
@@ -746,8 +746,8 @@ void cleanup(void)
             }
         }
 
-        std::cout << "Players deleted:  " << players_deleted << endl
-                  << "Players converted:  " << players_converted << endl;
+        std::cout << "Players deleted:  " << players_deleted << std::endl
+                  << "Players converted:  " << players_converted << std::endl;
         std::cout << "\n"
                   << file_count << " files\n"
                   << dir_count << " directories\n"

--- a/vme/src/db.cpp
+++ b/vme/src/db.cpp
@@ -231,7 +231,7 @@ struct diltemplate *generate_templates(FILE *f, class zone_type *zone)
 
          tmpl->prgname = str_dup(nBuf);
          str_lower(tmpl->prgname);
-         zone->mmp_tmpl.insert(make_pair(tmpl->prgname, tmpl));
+         zone->mmp_tmpl.insert(std::make_pair(tmpl->prgname, tmpl));
 
          /* Link into list of indexes */
 
@@ -283,7 +283,7 @@ void generate_file_indexes(FILE *f, class zone_type *zone)
       if (fread(&(temp_index->crc), sizeof(ubit32), 1, f) != 1)
          error(HERE, "Failed to fread() temp_index->crc");
 
-      zone->mmp_fi.insert(make_pair(temp_index->name, temp_index));
+      zone->mmp_fi.insert(std::make_pair(temp_index->name, temp_index));
       fi = temp_index;
       zone->no_of_fi++;
       fi->filepos = ftell(f);
@@ -355,7 +355,7 @@ void generate_zone_indexes(void)
    z->notes = str_dup(   "This zone is only here to allow us to use playername@_plaeyrs as with all "
    "other indexes such as mayor@midgaard. It's not actually a zone, and it's not a represenation "
    "of player files on disk\n");
-   zone_info.mmp.insert(make_pair(z->name, z));
+   zone_info.mmp.insert(std::make_pair(z->name, z));
    z = NULL;
 
    for (;;)
@@ -447,7 +447,7 @@ void generate_zone_indexes(void)
       }
 
       // Insert zone into sorted list
-      zone_info.mmp.insert(make_pair(z->name, z));
+      zone_info.mmp.insert(std::make_pair(z->name, z));
 
       int mstmp = fread(&z->weather.base, sizeof(int), 1, f);
       if (mstmp < 1)

--- a/vme/src/defcomp/defcomp.cpp
+++ b/vme/src/defcomp/defcomp.cpp
@@ -1,7 +1,6 @@
 #define   FALSE 0
 #define   TRUE   1
 #include  <ctype.h>
-using namespace std;
 #include <iostream>
 #include <string.h>
 #include <stdio.h>
@@ -21,7 +20,7 @@ int string_to_file(const char *name,const char *s)
 
     if (!out)
     {
-        cerr<<"Error in opening the "<<name<<" file."<<endl;
+        std::cerr<<"Error in opening the "<<name<<" file."<<std::endl;
         return (FALSE);
     }
 
@@ -164,13 +163,13 @@ char * convert_line(char *temp,int ln,char *save_buff)
 
     if ( strlen(token)<1)
     {
-        cerr<<"Erorr!  Line "<<ln<<":  No keyword value given."<<endl;
+        std::cerr<<"Erorr!  Line "<<ln<<":  No keyword value given."<<std::endl;
         return (NULL);
     }
 
     if (strlen(token)>20)
     {
-        cerr<<"Erorr!  Line "<<ln<<":  Keyword to long."<<endl;
+        std::cerr<<"Erorr!  Line "<<ln<<":  Keyword to long."<<std::endl;
         return (NULL);
     }
 
@@ -178,14 +177,14 @@ char * convert_line(char *temp,int ln,char *save_buff)
     {
         if (!isspace(*b))
         {
-            cerr<<"Erorr!  Line "<<ln<<":  Ilegal char in left hand value of '='"<<endl;
+            std::cerr<<"Erorr!  Line "<<ln<<":  Ilegal char in left hand value of '='"<<std::endl;
             return (NULL);
         }
         if ((*b=='\n') ||
                 (*b=='\r') ||
                 (*b=='\0'))
         {
-            cerr <<"Erorr!  Line "<<ln<<":  Missing '='"<<endl;
+            std::cerr <<"Erorr!  Line "<<ln<<":  Missing '='"<<std::endl;
             return (NULL);
         }
         b++;
@@ -196,14 +195,14 @@ char * convert_line(char *temp,int ln,char *save_buff)
         if ((!isspace(*b)) &&
                 (*b!='='))
         {
-            cerr<<"Erorr!  Line "<<ln<<":  Ilegal char in right hand value of '='"<<endl;
+            std::cerr<<"Erorr!  Line "<<ln<<":  Ilegal char in right hand value of '='"<<std::endl;
             return (NULL);
         }
         if ((*b=='\n') ||
                 (*b=='\r') ||
                 (*b=='\0'))
         {
-            cerr <<"Erorr!  Line "<<ln<<":  Missing right hand side of '='"<<endl;
+            std::cerr <<"Erorr!  Line "<<ln<<":  Missing right hand side of '='"<<std::endl;
             return (NULL);
         }
         b++;
@@ -225,13 +224,13 @@ char * convert_line(char *temp,int ln,char *save_buff)
 
     if (*b!='"')
     {
-        cerr <<"Erorr!  Line:  "<<ln<<":  Missing '\"'"<<endl;
+        std::cerr <<"Erorr!  Line:  "<<ln<<":  Missing '\"'"<<std::endl;
         return (NULL);
     }
 
     if (strlen(strval)<1)
     {
-        cerr<<"Erorr!  Line "<<ln<<":  No value inside '\"\"'"<<endl;
+        std::cerr<<"Erorr!  Line "<<ln<<":  No value inside '\"\"'"<<std::endl;
         return (NULL);
     }
 
@@ -255,7 +254,7 @@ char * convert_line(char *temp,int ln,char *save_buff)
     }
     else
     {
-        cerr<<"Error!  Line "<<ln<<":  "<<strval<<" is not a legal color value."<<endl;
+        std::cerr<<"Error!  Line "<<ln<<":  "<<strval<<" is not a legal color value."<<std::endl;
         return(NULL);
     }
 
@@ -295,7 +294,7 @@ int main (int argc, char **argv)
         in=fopen(in_name,"r");
         if (!in)
         {
-            cerr<<"In file not opened."<<endl;
+            std::cerr<<"In file not opened."<<std::endl;
             exit (1);
         }
 
@@ -312,9 +311,9 @@ int main (int argc, char **argv)
         fclose(in);
         exit (0);
     default:
-        cerr<<"You must supply the type of Define file."<<endl;
-        cerr<<"Example:"<<endl;
-        cerr<<"         defcomp -c  (To convert the color.def file)"<<endl;
+        std::cerr<<"You must supply the type of Define file."<<std::endl;
+        std::cerr<<"Example:"<<std::endl;
+        std::cerr<<"         defcomp -c  (To convert the color.def file)"<<std::endl;
         break;
     }
     exit (0);

--- a/vme/src/dilexp.cpp
+++ b/vme/src/dilexp.cpp
@@ -63,12 +63,9 @@ $Revision: 2.18 $
 #include <iostream>
 
 #include <iomanip>
-namespace fs = boost::filesystem;
 
 #include <boost/regex.hpp>
 #include <string>
-
-using namespace boost;
 
 struct time_info_data mud_date();
 extern struct trie_type *intr_trie;
@@ -130,9 +127,9 @@ void dilfe_replace(register class dilprg *p)
             case DILV_SP:
                 if (v->type == DILV_SP)
                 {
-                    string sch((char *) v1->val.ptr);
-                    string rpl((char *) v2->val.ptr);
-                    string mystr((char *) v3->val.ptr);
+                    std::string sch((char *) v1->val.ptr);
+                    std::string rpl((char *) v2->val.ptr);
+                    std::string mystr((char *) v3->val.ptr);
 
                     str_substitute(sch, rpl, mystr);
 
@@ -3043,7 +3040,7 @@ void *threadcallout(void *p)
 
     if (ok)
     {
-        string s;
+        std::string s;
         s = "./allow/";  // current dir iswhere vme/bin is located, set to bin/allow/
         s.append(str);
         slog(LOG_BRIEF , 0, "system('%s'); ", s.c_str());
@@ -3618,7 +3615,7 @@ void dilfe_udir(register class dilprg *p)
     dilval *v1 = p->stack.pop();
 
     cNamelist *words = new cNamelist;
-    string uPath, sPath;
+    std::string uPath, sPath;
 
     v->type = DILV_SLP;
 
@@ -3645,9 +3642,9 @@ void dilfe_udir(register class dilprg *p)
             if (sPath.empty())
                 sPath = ".*";
 
-            fs::path full_path(uPath);
-            fs::directory_iterator end_iter;
-            regex expression;
+            boost::filesystem::path full_path(uPath);
+            boost::filesystem::directory_iterator end_iter;
+            boost::regex expression;
 
             try
             {
@@ -3664,13 +3661,13 @@ void dilfe_udir(register class dilprg *p)
 
             try
             {
-                if ((fs::exists(full_path)) &&
-                    (fs::is_directory(full_path)))
-                    for (fs::directory_iterator dir_itr(full_path);
+                if ((boost::filesystem::exists(full_path)) &&
+                    (boost::filesystem::is_directory(full_path)))
+                    for (boost::filesystem::directory_iterator dir_itr(full_path);
                          dir_itr != end_iter;
                          ++dir_itr)
                     {
-                        cmatch what;
+                        boost::cmatch what;
 
                         if (regex_match(dir_itr->path().filename().c_str(), what, expression))
                         {
@@ -3713,7 +3710,7 @@ void dilfe_sdir(register class dilprg *p)
     dilval *v = new dilval;
     dilval *v1 = p->stack.pop();
     cNamelist *words = new cNamelist;
-    string uPath, sPath;
+    std::string uPath, sPath;
     v->type = DILV_SLP;
 
     switch (dil_getval(v1))
@@ -3738,10 +3735,10 @@ void dilfe_sdir(register class dilprg *p)
             if (sPath.empty())
                 sPath = ".*";
 
-            fs::path full_path(uPath);
-            fs::directory_iterator end_iter;
+            boost::filesystem::path full_path(uPath);
+            boost::filesystem::directory_iterator end_iter;
 
-            regex expression;
+            boost::regex expression;
 
             try
             {
@@ -3755,13 +3752,13 @@ void dilfe_sdir(register class dilprg *p)
 
             try
             {
-                if ((fs::exists(full_path)) &&
-                    (fs::is_directory(full_path)))
-                    for (fs::directory_iterator dir_itr(full_path);
+                if ((boost::filesystem::exists(full_path)) &&
+                    (boost::filesystem::is_directory(full_path)))
+                    for (boost::filesystem::directory_iterator dir_itr(full_path);
                          dir_itr != end_iter;
                          ++dir_itr)
                     {
-                        cmatch what;
+                        boost::cmatch what;
 
                         if (regex_match(dir_itr->path().filename().c_str(), what, expression))
                             words->dAppendName(dir_itr->path().filename().c_str());

--- a/vme/src/dilinst.cpp
+++ b/vme/src/dilinst.cpp
@@ -1336,15 +1336,15 @@ void dilfi_ass(register class dilprg *p)
             break;
 
         case DILV_NULL:
-            ((string *)v1->ref)->clear();
+            ((std::string *)v1->ref)->clear();
             break;
 
         case DILV_SP:
-            (*(string *)v1->ref) = ((char *)v2->val.ptr);
+            (*(std::string *)v1->ref) = ((char *)v2->val.ptr);
             break;
 
         case DILV_HASHSTR:
-            (*(string *)v1->ref) = (*(string *)v2->ref);
+            (*(std::string *)v1->ref) = (*(std::string *)v2->ref);
             break;
 
         default:
@@ -1375,7 +1375,7 @@ void dilfi_ass(register class dilprg *p)
 
         case DILV_HASHSTR:
             if (v2->ref)
-                *((char **)v1->ref) = str_dup(((string *)v2->ref)->c_str());
+                *((char **)v1->ref) = str_dup(((std::string *)v2->ref)->c_str());
             else
                 *((char **)v1->ref) = str_dup("");
             break;

--- a/vme/src/dilrun.cpp
+++ b/vme/src/dilrun.cpp
@@ -313,7 +313,7 @@ char dil_getbool(class dilval *v, class dilprg *prg)
 
     case DILV_HASHSTR:
         /* return Lvalue */
-        return ((string *)(v->ref))->empty();
+        return ((std::string *)(v->ref))->empty();
 
     case DILV_INT:
         return (v->val.num != 0); /* return Rvalue */
@@ -380,7 +380,7 @@ int dil_getval(class dilval *v)
         break;
     case DILV_HASHSTR:
         /* Important! Remember that the HASHSTR may NEVER EVER BE CHANGED! */
-        v->val.ptr = (char *)((string *)v->ref)->c_str();
+        v->val.ptr = (char *)((std::string *)v->ref)->c_str();
         break;
 
     case DILV_SLPR:

--- a/vme/src/experience.cpp
+++ b/vme/src/experience.cpp
@@ -768,7 +768,7 @@ int base_melee(class unit_data *att, class unit_data *def, int hit_loc)
 /* danger involved in combat (i.e. how fast would you die in worst case)    */
 /* Returns number of rounds it takes att to kill def                        */
 
-int base_consider(class unit_data *att, class unit_data *def, string *pStr)
+int base_consider(class unit_data *att, class unit_data *def, std::string *pStr)
 {
    int ocp, bonus;
    int att_wpn_type, def_arm_type;
@@ -801,7 +801,7 @@ void do_consider(class unit_data *ch, char *arg, const struct command_info *cmd)
    class unit_data *vict;
    int rtd;
    char *oarg = arg;
-   string str;
+   std::string str;
 
    if (IS_PC(ch) && PC_SKI_SKILL(ch, SKI_CONSIDER) == 0)
    {

--- a/vme/src/extra.cpp
+++ b/vme/src/extra.cpp
@@ -167,7 +167,7 @@ int extra_list::count(void)
 
 std::string extra_list::json(void)
 {
-    string s;
+    std::string s;
 
     s = "\"extralist\": [ ";
 

--- a/vme/src/extra.h
+++ b/vme/src/extra.h
@@ -58,7 +58,7 @@ public:
 
     class cintlist vals;
     class cNamelist names;	/* Keyword in look/examine          */
-    string descr;	/* What to see                      */
+    std::string descr;	/* What to see                      */
     class extra_descr_data *next;	/* Next in list                     */
 };
 

--- a/vme/src/handler.cpp
+++ b/vme/src/handler.cpp
@@ -616,10 +616,10 @@ class zone_type *unit_zone(const class unit_data *unit)
 //
 // Returns a symname text string of all the units a unit is in
 //
-string unit_trace_up(class unit_data *unit)
+std::string unit_trace_up(class unit_data *unit)
 {
     class unit_data *u;
-    string s, t;
+    std::string s, t;
 
     s = "";
     s.append(UNIT_FI_NAME(unit));

--- a/vme/src/handler.h
+++ b/vme/src/handler.h
@@ -73,6 +73,6 @@ void weight_change_unit (class unit_data * unit, int weight);
 class unit_data *find_unit_in_list_num (int num, class unit_data * list);
 class unit_data *find_unit_num (int num);
 
-string unit_trace_up(class unit_data *unit);
+std::string unit_trace_up(class unit_data *unit);
 
 #endif /* _MUD_HANDLER_H */

--- a/vme/src/intlist.cpp
+++ b/vme/src/intlist.cpp
@@ -94,7 +94,7 @@ char *cintlist::catnames()
 
 std::string cintlist::json(void)
 {
-    string s;
+    std::string s;
 
     s = "\"intlist\": [";
 

--- a/vme/src/intlist.h
+++ b/vme/src/intlist.h
@@ -11,7 +11,6 @@
 #include "essential.h"
 #include "bytestring.h"
 
-using namespace std;
 #include <string>
 
 class cintlist

--- a/vme/src/justice.cpp
+++ b/vme/src/justice.cpp
@@ -1075,7 +1075,7 @@ int reward_give(struct spec_arg *sarg)
 
    class unit_data *u;
    class unit_affected_type *paf;
-   string buf;
+   std::string buf;
    currency_t cur;
 
    if (!is_command(sarg->cmd, "give"))

--- a/vme/src/mplex2/mplex.cpp
+++ b/vme/src/mplex2/mplex.cpp
@@ -242,7 +242,7 @@ int main(int argc, char *argv[])
     {
         /* MS2020 Websockets test hack */
         void runechoserver(void);
-        thread t1(runechoserver);
+        std::thread t1(runechoserver);
         t1.detach();
     }
     else

--- a/vme/src/namelist.cpp
+++ b/vme/src/namelist.cpp
@@ -141,7 +141,7 @@ char *cNamelist::catnames()
 
 std::string cNamelist::json(void)
 {
-    string s;
+    std::string s;
 
     s = "\"namelist\": [";
 
@@ -164,7 +164,7 @@ void cNamelist::Remove(ubit32 idx)
         delete namelist[idx];
         if (idx != length - 1)
             memmove (&namelist[idx], &namelist[idx + 1],
-                     sizeof(string *) * (length - idx - 1));
+                     sizeof(std::string *) * (length - idx - 1));
         length--;
         if (length == 0)
         {
@@ -172,7 +172,7 @@ void cNamelist::Remove(ubit32 idx)
         }
         else
         {
-            RECREATE(namelist, string *, length);
+            RECREATE(namelist, std::string *, length);
         }
     }
 }
@@ -201,7 +201,7 @@ void cNamelist::Substitute (ubit32 idx, const char *newname)
     if (length > idx)
     {
         delete namelist[idx];
-        namelist[idx] = new string (newname?newname:"");
+        namelist[idx] = new std::string (newname?newname:"");
     }
 }
 
@@ -377,7 +377,7 @@ const char *cNamelist::Name(ubit32 idx)
 }
 
 
-string *cNamelist::InstanceName (ubit32 idx)
+std::string *cNamelist::InstanceName (ubit32 idx)
 {
     if (idx < length)
         return namelist[idx];
@@ -394,13 +394,13 @@ void cNamelist::dAppendName (const char *name)
 
     if (namelist == NULL)
     {
-        CREATE (namelist, string *, length);
+        CREATE (namelist, std::string *, length);
     }
     else
     {
-        RECREATE (namelist, string *, length);
+        RECREATE (namelist, std::string *, length);
     }
-    namelist[length - 1] = new string (name?name:"");
+    namelist[length - 1] = new std::string (name?name:"");
 }
 
 
@@ -412,13 +412,13 @@ void cNamelist::AppendName (const char *name)
 
     if (namelist == NULL)
     {
-        CREATE (namelist, string *, length);
+        CREATE (namelist, std::string *, length);
     }
     else
     {
-        RECREATE (namelist, string *, length);
+        RECREATE (namelist, std::string *, length);
     }
-    namelist[length - 1] = new string (name?name:"");
+    namelist[length - 1] = new std::string (name?name:"");
 
 }
 
@@ -431,16 +431,16 @@ void cNamelist::PrependName (const char *name)
 
     if (namelist == NULL)
     {
-        CREATE (namelist, string *, length);
+        CREATE (namelist, std::string *, length);
     }
     else
     {
-        RECREATE (namelist, string *, length);
+        RECREATE (namelist, std::string *, length);
     }
     if (length > 1)
-        memmove (&namelist[1], &namelist[0], sizeof (string *) * (length - 1));
+        memmove (&namelist[1], &namelist[0], sizeof (std::string *) * (length - 1));
 
-    namelist[0] = new string (name?name:"");
+    namelist[0] = new std::string (name?name:"");
 }
 
 void
@@ -464,21 +464,21 @@ cNamelist::InsertName (const char *name, ubit32 loc)
 
     if (namelist == NULL)
     {
-        CREATE (namelist, string *, length);
+        CREATE (namelist, std::string *, length);
     }
     else
     {
-        RECREATE (namelist, string *, length);
+        RECREATE (namelist, std::string *, length);
     }
     if (olen != loc)
     {
         if (length > 1)
             if (nadd == 1)
                 memmove (&namelist[loc + 1], &namelist[loc],
-                         sizeof (string *) * (olen - loc));
+                         sizeof (std::string *) * (olen - loc));
     }
-    namelist[loc] = new string (name?name:"");
+    namelist[loc] = new std::string (name?name:"");
     if (nadd > 1)
         for (x = length - nadd; x < (length - 1); x++)
-            namelist[x] = new string ("");
+            namelist[x] = new std::string ("");
 }

--- a/vme/src/namelist.h
+++ b/vme/src/namelist.h
@@ -9,7 +9,6 @@
 #define _MUD_NAMELIST_H
 
 #include "bytestring.h"
-using namespace std;
 #include <string>
 
 class cNamelist
@@ -37,7 +36,7 @@ public:
 
     void Substitute (ubit32 idx, const char *newname);
     const char *Name (ubit32 idx = 0);
-    string *InstanceName (ubit32 idx = 0);
+    std::string *InstanceName (ubit32 idx = 0);
 
     void AppendName (const char *name);
     void dAppendName (const char *name);
@@ -60,7 +59,7 @@ public:
     }
 
 private:
-    string ** namelist;
+    std::string ** namelist;
     ubit32 length;
 };
 

--- a/vme/src/path.cpp
+++ b/vme/src/path.cpp
@@ -38,15 +38,13 @@ pthread_t dijkstra_thread;
 
 extern unit_data *room_head;
 
-using namespace boost;
-
 std::vector<graph_t> sc_graphs;
 std::vector<std::vector<unit_data *>> sc_room_ptr;
 
 void create_worldgraph()
 {
     graph_world_t WorldGraph;
-    typedef graph_traits<graph_world_t>::vertex_descriptor vertex_descriptor;
+    typedef boost::graph_traits<graph_world_t>::vertex_descriptor vertex_descriptor;
     //	typedef graph_traits < graph_world_t >::edge_descriptor edge_descriptor;
     vertex_descriptor vd;
     unit_data *u, *uu;
@@ -82,7 +80,7 @@ void create_worldgraph()
     std::vector<vertex_descriptor> sc(num_vertices(WorldGraph));
     i = strong_components(WorldGraph,
                           make_iterator_property_map(sc.begin(),
-                                                     get(vertex_index,
+                                                     get(boost::vertex_index,
                                                          WorldGraph)));
     std::vector<vertex_descriptor>
         sc_num(i);
@@ -132,7 +130,7 @@ void *create_sc_dijkstra(void *thread)
             ROOM_DISTANCE(u).resize(num_vertices(sc_graphs[ROOM_SC(u)]));
 
             dijkstra_shortest_paths(sc_graphs[ROOM_SC(u)], ROOM_NUM(u),
-                                    predecessor_map(&ROOM_PATH(u)[0]).distance_map(&ROOM_DISTANCE(u)[0]));
+                                    boost::predecessor_map(&ROOM_PATH(u)[0]).distance_map(&ROOM_DISTANCE(u)[0]));
             ROOM_WAITD(u) = FALSE;
         }
         usleep(10000);
@@ -147,8 +145,8 @@ void *create_sc_dijkstra(void *thread)
 void create_sc_graph(int num_of_sc)
 {
     int sc = 0;
-    typedef graph_traits<graph_t>::vertex_descriptor vertex_descriptor;
-    typedef graph_traits<graph_t>::edge_descriptor edge_descriptor;
+    typedef boost::graph_traits<graph_t>::vertex_descriptor vertex_descriptor;
+    typedef boost::graph_traits<graph_t>::edge_descriptor edge_descriptor;
     int i;
     vertex_descriptor vd;
     unit_data *u, *uu;
@@ -172,7 +170,7 @@ void create_sc_graph(int num_of_sc)
                 ROOM_NUM(u) = vd;
             }
 
-        property_map<graph_t, edge_dir_t>::type dir = get(edge_dir, sc_graphs[sc]);
+        boost::property_map<graph_t, boost::edge_dir_t>::type dir = get(boost::edge_dir, sc_graphs[sc]);
 
         for (u = room_head; u && UNIT_TYPE(u) == UNIT_ST_ROOM; u = u->gnext)
         {
@@ -241,7 +239,7 @@ int path_weight(unit_data *from, unit_data *to, int dir)
 /* Primitive move generator, returns direction */
 int move_to(unit_data *from, unit_data *to)
 {
-    typedef graph_traits<graph_t>::edge_descriptor edge_descriptor;
+    typedef boost::graph_traits<graph_t>::edge_descriptor edge_descriptor;
     edge_descriptor ed;
     bool success;
     int i, next;
@@ -279,7 +277,7 @@ int move_to(unit_data *from, unit_data *to)
         i = ROOM_PATH(from)[i];
     }
 
-    property_map<graph_t, edge_dir_t>::type dir = get(edge_dir, sc_graphs[ROOM_SC(from)]);
+    boost::property_map<graph_t, boost::edge_dir_t>::type dir = get(boost::edge_dir, sc_graphs[ROOM_SC(from)]);
     tie(ed, success) = edge(ROOM_NUM(from), next, sc_graphs[ROOM_SC(from)]);
     if (success)
         return (dir[ed]);

--- a/vme/src/path.h
+++ b/vme/src/path.h
@@ -21,18 +21,15 @@ void create_sc_graph (int num_of_sc);
 void create_sc_dijkstra ();
 extern unit_data *room_head;
 
-using namespace boost;
 namespace boost {
 enum edge_dir_t { edge_dir = 101 };
 BOOST_INSTALL_PROPERTY(edge, dir);
 }
 
-typedef adjacency_list < vecS, vecS, directedS, no_property,
-        property < edge_weight_t, int > >graph_world_t;
-typedef adjacency_list < vecS, vecS, directedS, no_property,
-        property < edge_weight_t, int,
-        property < edge_dir_t, int > > >graph_t;
+typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS, boost::no_property,
+                              boost::property<boost::edge_weight_t, int>> graph_world_t;
+typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS, boost::no_property,
+                              boost::property<boost::edge_weight_t, int, boost::property<boost::edge_dir_t, int>>> graph_t;
 
 extern std::vector < graph_t > sc_graphs;
 extern std::vector < std::vector< unit_data * > >sc_room_ptr;
-using namespace std;

--- a/vme/src/pcsave.cpp
+++ b/vme/src/pcsave.cpp
@@ -47,7 +47,7 @@ void assign_player_file_index(unit_data *pc)
         fi->zone = z;
         fi->type = UNIT_ST_PC;
 
-        z->mmp_fi.insert(make_pair(fi->name, fi));
+        z->mmp_fi.insert(std::make_pair(fi->name, fi));
 
         UNIT_FILE_INDEX(pc) = fi;
     }

--- a/vme/src/pipe.cpp
+++ b/vme/src/pipe.cpp
@@ -172,7 +172,7 @@ public:
       }
 
       int n;
-      string str;
+      std::string str;
 
       str = c;
       str.append("\n");
@@ -241,4 +241,3 @@ void namedpipe_setup(void)
 {
    g_pipeMUD_RO.Open();
 }
-

--- a/vme/src/sector.cpp
+++ b/vme/src/sector.cpp
@@ -14,7 +14,7 @@ extern cSector sector_dat;
 
 
 
-string cSector::get_name(int sector) {
+std::string cSector::get_name(int sector) {
     if ((sector >=0) && (sector < (int)names.size()))
         return (names[sector]);
     else
@@ -41,7 +41,7 @@ int cSector::get_enduance_cost (int from, int to) {
         return(1);
 };
 
-void cSector::add_sector( int sector, string sector_name )
+void cSector::add_sector( int sector, std::string sector_name )
 {
     if (sector < 0) return;
 
@@ -116,10 +116,10 @@ void cSector::set_path_endurance_cost (int from, int to, int pcost, int ecost)
 void boot_sector(void)
 {
 
-    ifstream in_file;
-    string temp;
-    vector<string> sector_vect;
-    queue<int> sector_queue;
+    std::ifstream in_file;
+    std::string temp;
+    std::vector<std::string> sector_vect;
+    std::queue<int> sector_queue;
 
 
     in_file.open(str_cc  (g_cServerConfig.m_libdir, SECTOR_DEFS));
@@ -202,5 +202,3 @@ void boot_sector(void)
         }
     }
 }
-
-

--- a/vme/src/sector.h
+++ b/vme/src/sector.h
@@ -3,23 +3,23 @@
 #include <vector>
 #include <string>
 #include "vme.h"
-using namespace std;
+
 class cSector
 {
 private:
-    std::vector< string > names;
+    std::vector< std::string > names;
     std::vector< std::vector < int > > endurance;
     std::vector< std::vector < int > > path;
 
 public:
 
-    string get_name(int sector);
+    std::string get_name(int sector);
     inline int get_num_of_sectors() {
         return ((int)names.size());
     };
     int get_path_cost(int from, int to);
     int get_enduance_cost (int from, int to);
-    void add_sector( int sector, string sector_name );
+    void add_sector( int sector, std::string sector_name );
     void add_sector( int sector, char *sector_name );
     void set_path_cost (int from, int to, int cost);
     void set_endurance_cost (int from, int to, int cost);

--- a/vme/src/skills.cpp
+++ b/vme/src/skills.cpp
@@ -945,7 +945,7 @@ static void ability_init(void)
     g_AbiColl.text[ABIL_TREE_MAX] = NULL;
 }
 
-bool pairISCompare(const std::pair<int, string>& firstElem, const std::pair<int, string>& secondElem)
+bool pairISCompare(const std::pair<int, std::string>& firstElem, const std::pair<int, std::string>& secondElem)
 {
     return firstElem.first > secondElem.first;
 }
@@ -953,12 +953,12 @@ bool pairISCompare(const std::pair<int, string>& firstElem, const std::pair<int,
 
 void ability_dump(void)
 {
-    string str;
+    std::string str;
     char buf[MAX_STRING_LENGTH];
 
     for (int j = 0; j < PROFESSION_MAX; j++)
     {
-        vector< pair <int,string> > vect; 
+        std::vector< std::pair <int,std::string> > vect;
 
         for (int i = 0; i < ABIL_TREE_MAX; i++)
         {
@@ -1325,12 +1325,12 @@ static void weapon_init(void)
 
 void weapon_dump(void)
 {
-    string str;
+    std::string str;
     char buf[MAX_STRING_LENGTH];
 
     for (int j = 0; j < PROFESSION_MAX; j++)
     {
-        vector< pair <int,string> > vect; 
+        std::vector< std::pair <int,std::string> > vect;
 
         for (int i = WPN_GROUP_MAX; i < WPN_TREE_MAX; i++)
         {

--- a/vme/src/spell_parser.cpp
+++ b/vme/src/spell_parser.cpp
@@ -875,14 +875,14 @@ static void spell_init(void)
 
 void spell_dump(void)
 {
-    string str;
+    std::string str;
     char buf[MAX_STRING_LENGTH];
 
-    bool pairISCompare(const std::pair<int, string>& firstElem, const std::pair<int, string>& secondElem);
+    bool pairISCompare(const std::pair<int, std::string>& firstElem, const std::pair<int, std::string>& secondElem);
 
     for (int j = 0; j < PROFESSION_MAX; j++)
     {
-        vector< pair <int,string> > vect; 
+        std::vector< std::pair <int,std::string> > vect;
 
         for (int i = 0; i < SPL_TREE_MAX; i++)
         {

--- a/vme/src/structs.cpp
+++ b/vme/src/structs.cpp
@@ -571,8 +571,8 @@ void unit_data::set_fi(class file_index_type *f)
 
 std::string unit_data::json(void)
 {
-    string s;
-    string t;
+    std::string s;
+    std::string t;
 
     t = UNIT_FI_NAME(this);
     t.append("@");

--- a/vme/src/structs.h
+++ b/vme/src/structs.h
@@ -20,13 +20,11 @@
 #include "color.h"
 #include "destruct.h"
 #include "dil.h"
-using namespace std;
 #include <vector>
 #include <map>
 #ifndef MPLEX_COMPILE
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/adjacency_list.hpp>
-using namespace boost;
 #endif
 #define FI_MAX_ZONENAME 30 /* Max length of any zone-name    */
 #define FI_MAX_UNITNAME 15 /* Max length of any unit-name    */
@@ -304,13 +302,13 @@ public:
     sbit16 alignment; /* +-1000 for alignments                         */
 
     /* Room title, Char title, Obj "the barrel", NPC "the Beastly Fido" */
-    string title;
+    std::string title;
 
     /* The outside description of a unit           */
-    string out_descr;
+    std::string out_descr;
 
     /* The inside description of a unit            */
-    string in_descr;
+    std::string in_descr;
 
     class extra_list extra;  /* All the look 'at' stuff                     */
 
@@ -359,12 +357,11 @@ public:
         edge_dir = 101
     };
 
-    typedef adjacency_list<vecS, vecS, directedS, no_property,
-                           property<edge_weight_t, int,
-                                    property<edge_dir_t, int> > >
+    typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS, boost::no_property,
+                                  boost::property<boost::edge_weight_t, int, boost::property<edge_dir_t, int>>>
         graph_t;
 
-    typedef graph_traits<graph_t>::vertex_descriptor vertex_descriptor;
+    typedef boost::graph_traits<graph_t>::vertex_descriptor vertex_descriptor;
     std::vector<vertex_descriptor> path;
     std::vector<vertex_descriptor> distance;
     int waiting_dijkstra;

--- a/vme/src/teach.cpp
+++ b/vme/src/teach.cpp
@@ -269,7 +269,7 @@ void info_show_one(class unit_data *teacher,
                    const char *text,
                    int indent, ubit8 isleaf, int min_level,
                    struct profession_cost *cost_entry,
-                   vector<pair<int, string>> &vect)
+                   std::vector<std::pair<int, std::string>> &vect)
 {
    char buf[256];
 
@@ -310,11 +310,11 @@ void info_show_one(class unit_data *teacher,
                     next_point >= 20 ? "<div class='ca'>" : "", spc(4 * indent), current_points, text, current_points, max_level,
                     next_point,
                     money_string(money_round(TRUE, gold, currency, 1), currency, FALSE),
-                    string(lvl, '*').c_str(), next_point >= 20 ? "</div>" : "");
+                    std::string(lvl, '*').c_str(), next_point >= 20 ? "</div>" : "");
          else
             sprintf(buf, "%s%s%3d%% %-20s [practice points %3d] %s%s<br/>",
                     next_point >= 20 ? "<div class='ca'>" : "", spc(4 * indent), current_points, text,
-                    next_point, string(lvl, '*').c_str(), next_point >= 20 ? "</div>" : "");
+                    next_point, std::string(lvl, '*').c_str(), next_point >= 20 ? "</div>" : "");
 
          vect.push_back(std::make_pair(next_point, buf));
       }
@@ -326,7 +326,7 @@ void info_show_one(class unit_data *teacher,
    }
 }
 
-bool pairISCompareAsc(const std::pair<int, string> &firstElem, const std::pair<int, string> &secondElem)
+bool pairISCompareAsc(const std::pair<int, std::string> &firstElem, const std::pair<int, std::string> &secondElem)
 {
    return firstElem.first < secondElem.first;
 }
@@ -337,7 +337,7 @@ void info_show_roots(class unit_data *teacher, class unit_data *pupil,
                      struct skill_teach_type *teaches_skills)
 {
    int i, cost;
-   vector<pair<int, string>> vect;
+   std::vector<std::pair<int, std::string>> vect;
 
    for (i = 0; teaches_skills[i].node != -1; i++)
       if ((!TREE_ISROOT(pColl->tree, teaches_skills[i].node) &&
@@ -363,7 +363,7 @@ void info_show_roots(class unit_data *teacher, class unit_data *pupil,
 
    std::sort(vect.begin(), vect.end(), pairISCompareAsc);
 
-   string str;
+   std::string str;
    str = "<pre>";
    for (auto it = vect.begin(); it != vect.end(); ++it)
       str.append(it->second.c_str());
@@ -381,7 +381,7 @@ void info_show_leaves(class unit_data *teacher, class unit_data *pupil,
                       struct pc_train_values *pTrainValues)
 {
    int i, cost;
-   vector<pair<int, string>> vect;
+   std::vector<std::pair<int, std::string>> vect;
 
    for (i = 0; teaches_skills[i].node != -1; i++)
       if (TREE_ISLEAF(pColl->tree, teaches_skills[i].node))
@@ -403,7 +403,7 @@ void info_show_leaves(class unit_data *teacher, class unit_data *pupil,
       }
 
    std::sort(vect.begin(), vect.end(), pairISCompareAsc);
-   string str;
+   std::string str;
    str = "<pre>";
    for (auto it = vect.begin(); it != vect.end(); ++it)
    {
@@ -426,7 +426,7 @@ void info_one_skill(class unit_data *teacher, class unit_data *pupil,
 {
    int indent, i, j, cost;
    indent = 0;
-   vector<pair<int, string>> vect;
+   std::vector<std::pair<int, std::string>> vect;
 
    /* Find category if index is a leaf with a category parent */
 
@@ -508,7 +508,7 @@ void info_one_skill(class unit_data *teacher, class unit_data *pupil,
    }
 
    std::sort(vect.begin(), vect.end(), pairISCompareAsc);
-   string str;
+   std::string str;
    str = "<pre>";
    for (auto it = vect.begin(); it != vect.end(); ++it)
       str.append(it->second.c_str());

--- a/vme/src/textutil.cpp
+++ b/vme/src/textutil.cpp
@@ -1413,7 +1413,7 @@ const char *getHTMLTag(const char *p, char *pTag, int nTagMax)
 
     n = c - p + 1; // How many chars including \0
 
-    n = min(n, nTagMax);
+    n = std::min(n, nTagMax);
 
     for (int i = 0; i < n; i++)
         pTag[i] = tolower(*(p + i));
@@ -1543,7 +1543,7 @@ const char *divcolor(const char *colorstr)
 // Encode str to JSON encoding (format X)
 std::string str_json_encode(const char *str)
 {
-    string s;
+   std::string s;
 
     s = str;
 
@@ -1556,7 +1556,7 @@ std::string str_json_encode(const char *str)
 // As str_json_encode but wraps string in quotes
 std::string str_json_encode_quote(const char *str)
 {
-    string s;
+   std::string s;
 
     s = "\"";
     s.append(str_json_encode(str));
@@ -1567,7 +1567,7 @@ std::string str_json_encode_quote(const char *str)
 
 std::string str_json(const char *lbl, ubit64 nInt)
 {
-    string s;
+   std::string s;
 
     s.append("\"");
     s.append(str_json_encode(lbl));
@@ -1580,7 +1580,7 @@ std::string str_json(const char *lbl, ubit64 nInt)
 
 std::string str_json(const char *lbl, const char *str)
 {
-    string s;
+    std::string s;
 
     s.append("\"");
     s.append(lbl);

--- a/vme/src/vmc/vmc.cpp
+++ b/vme/src/vmc/vmc.cpp
@@ -16,8 +16,6 @@
 #include <sstream>
 
 
-using namespace std;
-
 #ifdef WINDOWS
 
 #else
@@ -780,14 +778,13 @@ void dil_free_template (struct diltemplate *tmpl, int copy, int dil)
 void
 graph_sc( char *prefix )
 {
-    using namespace boost;
     class unit_data *u;
     int x;
     for (x=0,u=zone.z_rooms; u; u=u->next,x++)
         if (IS_ROOM(u))
             ROOM_NUM(u)=x;
 
-    typedef adjacency_list<> ZoneGraph;
+    typedef boost::adjacency_list<> ZoneGraph;
 
     ZoneGraph G(x);
     for (u=zone.z_rooms; u; u=u->next)
@@ -803,29 +800,29 @@ void
 write_dot (char *prefix)
 {
     char dotfilename[256];
-    ostringstream interconnect;
+    std::ostringstream interconnect;
     class unit_data *u;
     sprintf (dotfilename, "%s.%s", prefix, "dot");
-    ofstream dotfl (dotfilename);
+    std::ofstream dotfl (dotfilename);
     if (!(dotfl))
     {
         perror (dotfilename);
         exit (1);
     }
 
-    dotfl << "subgraph \"cluster@" << zone.z_zone.name << "\" {" << endl <<
-          "  label=\"" << zone.z_zone.name << "\";" << endl;
+    dotfl << "subgraph \"cluster@" << zone.z_zone.name << "\" {" << std::endl <<
+          "  label=\"" << zone.z_zone.name << "\";" << std::endl;
 
-    dotfl << endl << "  /* Room Labels */" << endl;
+    dotfl << std::endl << "  /* Room Labels */" << std::endl;
 
     for (u = zone.z_rooms; u; u = u->next)
     {
         if (IS_ROOM (u))
             dotfl << "\"" << UNIT_IDENT (u) << "@" << zone.z_zone.name << "\" "
-                  << "[label=\"" << UNIT_IDENT (u) << "\"];" << endl;
+                  << "[label=\"" << UNIT_IDENT (u) << "\"];" << std::endl;
     }
 
-    dotfl << endl << "/* Room Interconnects */" << endl;
+    dotfl << std::endl << "/* Room Interconnects */" << std::endl;
     for (u = zone.z_rooms; u; u = u->next)
     {
         if (IS_ROOM (u))
@@ -847,20 +844,20 @@ write_dot (char *prefix)
                     if (strcmp (c1, zone.z_zone.name) == 0)
                     {
                         dotfl << "\"" << UNIT_IDENT (u) << "@" << zone.z_zone.name
-                              << "\"->\"" << c2 << "@" << c1 << "\";" << endl;
+                              << "\"->\"" << c2 << "@" << c1 << "\";" << std::endl;
                     }
                     else
                     {
                         interconnect << "\"" << UNIT_IDENT (u) << "@"
                                      << zone.z_zone.name
-                                     << "\"->\"" << c2 << "@" << c1 << "\";" << endl;
+                                     << "\"->\"" << c2 << "@" << c1 << "\";" << std::endl;
                     }
                 }
             }
     }
-    dotfl <<  "}" << endl;
-    dotfl << endl << "/*  Zone Interconnect Points */" << endl << endl;
-    interconnect << endl << "/*  End of subgraph "<< zone.z_zone.name << " */" << endl << ends;
-    dotfl << interconnect.str() << endl;
+    dotfl <<  "}" << std::endl;
+    dotfl << std::endl << "/*  Zone Interconnect Points */" << std::endl << std::endl;
+    interconnect << std::endl << "/*  End of subgraph "<< zone.z_zone.name << " */" << std::endl << std::ends;
+    dotfl << interconnect.str() << std::endl;
     dotfl.close();
 }


### PR DESCRIPTION
Cent 7 is getting errors with older compiler trying to compile
dilpar.y because std::namespace was imported and its clashing with
STL's std::ref

eg
../DikuMUD3_priv/vme/src/vmc/dilpar.y:5942:21: error: reference to ‘ref’ is ambiguous
             explist[ref.argc] = $1;

I removed boost's too.