### PR TITLE
Avoid sliming holiday 2020 items

### DIFF
--- a/vme/etc/zonelist
+++ b/vme/etc/zonelist
@@ -40,6 +40,7 @@ justice 1120tw0008       1   0 250 0 ../lib/justice
 arena release            1   0 250 0
 clan 1120tw0008          1   0 250 0 ../lib/clan
 competition 1120tw0008   1   0 250 0 ../lib/competition
+holiday20 release    1   0 250 0
 holiday21 release		 1   0 250 0 
 guild_quest release		 1	 0 250 0 
 #


### PR DESCRIPTION
Should prevent sliming holiday 2020 items on any more characters that haven't logged in yet, as it looks like things slime on login.