### PR TITLE
Create small git pre commit hook

### DIFF
--- a/githooks/README.md
+++ b/githooks/README.md
@@ -1,0 +1,9 @@
+## To run clang-format each time you commit
+
+Copy the pre-commit script here into the git hooks directory for the
+project. 
+
+eg.
+
+    cd <project top level>/githooks
+    cp pre-commit ../.git/hooks/.

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/sh
+for FILE in $(git diff --cached --name-only)
+do
+   if [[ "$FILE" =~ \.(c|h|cpp|cc)$ ]]; then
+      echo "Reformatting with clang-format: $FILE"
+      clang-format -i $FILE
+      git add $FILE
+   fi
+   if [ "$(git diff --cached --name-only | wc -l)" -lt "1" ]; then
+      echo "No files changed after clang-formating"
+      exit 2 #Abandon commit - no files
+   fi
+done
+exit 0


### PR DESCRIPTION
Copying this file to your git hooks directory will ensure
clang-format is run on all the .c/.h/.cpp/.cc files before
commiting.