### PR TITLE
Convert connection ip addresse to ipv4 if possible

### DIFF
--- a/vme/src/mplex2/echo_server.cpp
+++ b/vme/src/mplex2/echo_server.cpp
@@ -87,7 +87,22 @@ void on_message(wsserver *s, websocketpp::connection_hdl hdl, message_ptr msg)
         // Get the IP address
         const auto theip = s->get_con_from_hdl(hdl);
         boost::asio::ip::address theadr = theip->get_raw_socket().remote_endpoint().address();
-        strncpy(con->m_aHost, theadr.to_string().c_str(), sizeof(con->m_aHost) - 1);
+        std::string ip_as_string{theadr.to_string()};
+        if (theadr.is_v6())
+        {
+            auto v6 = boost::asio::ip::make_address_v6(theadr.to_string());
+            // Lets hope it is a ipv4 mapped to ipv6 address space
+            if (v6.is_v4_mapped())
+            {
+                auto v4 = boost::asio::ip::make_address_v4(boost::asio::ip::v4_mapped_t::v4_mapped, v6);
+                ip_as_string = v4.to_string();
+            }
+            else
+            {
+                ip_as_string = boost::asio::ip::address_v4::any().to_string();
+            }
+        }
+        strncpy(con->m_aHost, ip_as_string.c_str(), sizeof(con->m_aHost) - 1);
         *(con->m_aHost + sizeof(con->m_aHost) - 1) = '\0';
         slog(LOG_OFF, 0, "IP connection from: %s", con->m_aHost);
     }


### PR DESCRIPTION
CServerConfiguration::FromLAN() currently expects
a dotted ipv4 address string only. In
echo_server.cpp:on_message() boost::asio is returning
an ip::address which is generic that holds an ipv4
address mapped to ipv6 space because mplex is
listening on a ipv6 interface.

If the address is mappable back to ipv4 return a ipv4
dotted string or return 0.0.0.0