### PR TITLE
Preperation and script for clang-tidy readability braces

### DIFF
--- a/clang-tidy-braces.sh
+++ b/clang-tidy-braces.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# https://clang.llvm.org/extra/clang-tidy/checks/readability-braces-around-statements.html
+
+which clang-tidy-12 > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+   echo -e "\n\nERROR: clang-tidy needs to be installed"
+   echo -e "\n    sudo apt-get install clang-tidy-12\n\n"
+   exit 1
+fi
+
+sources="vme/src/account.cpp vme/src/act_change.cpp vme/src/act_color.cpp vme/src/act_info.cpp vme/src/act_movement.cpp vme/src/act_offensive.cpp vme/src/act_other.cpp vme/src/act_skills.cpp vme/src/act_wizard.cpp vme/src/act_wstat.cpp vme/src/affect.cpp vme/src/apf_affect.cpp vme/src/badnames.cpp vme/src/ban.cpp vme/src/bank.cpp vme/src/bytestring.cpp vme/src/cmdload.cpp vme/src/color.cpp vme/src/combat.cpp vme/src/comm.cpp vme/src/common.cpp vme/src/config.cpp vme/src/constants.cpp vme/src/convert.cpp vme/src/db.cpp vme/src/db_file.cpp vme/src/dbfind.cpp vme/src/defcomp/defcomp.cpp vme/src/defcomp/main.cpp vme/src/destruct.cpp vme/src/dictionary.cpp vme/src/dilexp.cpp vme/src/dilfld.cpp vme/src/dilinst.cpp vme/src/dilrun.cpp vme/src/dilshare.cpp vme/src/dilsup.cpp vme/src/eliza.cpp vme/src/event.cpp vme/src/experience.cpp vme/src/extra.cpp vme/src/fight.cpp vme/src/files.cpp vme/src/guild.cpp vme/src/handler.cpp vme/src/hook.cpp vme/src/hookmud.cpp vme/src/interpreter.cpp vme/src/intlist.cpp vme/src/justice.cpp vme/src/magic.cpp vme/src/main.cpp vme/src/main_functions.cpp vme/src/membug.cpp vme/src/mobact.cpp vme/src/modify.cpp vme/src/money.cpp vme/src/mplex2/ClientConnector.cpp vme/src/mplex2/MUDConnector.cpp vme/src/mplex2/echo_server.cpp vme/src/mplex2/main.cpp vme/src/mplex2/mplex.cpp vme/src/mplex2/network.cpp vme/src/mplex2/translate.cpp vme/src/namelist.cpp vme/src/nanny.cpp vme/src/nice.cpp vme/src/path.cpp vme/src/pcsave.cpp vme/src/pipe.cpp vme/src/protocol.cpp vme/src/queue.cpp vme/src/reception.cpp vme/src/sector.cpp vme/src/signals.cpp vme/src/skills.cpp vme/src/slime.cpp vme/src/spec_assign.cpp vme/src/spec_procs.cpp vme/src/spell_parser.cpp vme/src/str_parse.cpp vme/src/structs.cpp vme/src/system.cpp vme/src/teach.cpp vme/src/textutil.cpp vme/src/tif_affect.cpp vme/src/trie.cpp vme/src/unitfind.cpp vme/src/utility.cpp vme/src/vmc/main.cpp vme/src/vmc/vmc.cpp vme/src/vmc/vmc_process.cpp vme/src/vmelimits.cpp vme/src/weather.cpp vme/src/zon_basis.cpp vme/src/zon_wiz.cpp vme/src/zone_reset.cpp"
+
+# Create clean fresh compile_commands.json file for clang-tidy
+mkdir tidy_comp_db
+pushd tidy_comp_db
+cmake ..
+popd
+
+for source in $sources
+do
+   echo "Selecting [$source] as next victim for braces!"
+   clang-tidy-12 -p tidy_comp_db --checks="-*,readability-braces-around-statements" --fix $source || exit 1
+   clang-format -i $source
+done
+
+echo -e "\n\nFINISHED!\nYou can delete $0 and 'tidy_comp_db' now"
+echo -e "\n     rm -rf tidy_comp_db"
+echo -e "     rm $0\n\n"

--- a/vme/src/db_file.cpp
+++ b/vme/src/db_file.cpp
@@ -1078,11 +1078,13 @@ int write_unit_string(CByteBuffer *pBuf, class unit_data *u)
         if (IS_PC(u))
             inu = CHAR_LAST_ROOM(u);
         else if (UNIT_IN(u))
+        {
 #ifdef DMSERVER
             inu = unit_room(u);
 #else
             assert(inu == NULL);
 #endif
+        }
 
         if (inu && UNIT_FILE_INDEX(inu))
         {

--- a/vme/src/dilexp.cpp
+++ b/vme/src/dilexp.cpp
@@ -1872,11 +1872,13 @@ void dilfe_svstr(class dilprg *p)
                                 }
                                 strcat(filename, "/strings/");
                                 if (!file_exists(filename))
+                                {
 #ifdef _WINDOWS
                                     _mkdir(filename);
 #else
                                     mkdir(filename, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IXGRP);
 #endif
+                                }
                                 strcat(filename, (char *)v1->val.ptr);
                                 sstr = str_dup((char *)v2->val.ptr);
                                 v->val.num = save_string(filename, &sstr, (char *)v3->val.ptr);
@@ -1957,11 +1959,13 @@ void dilfe_filesz(class dilprg *p)
             }
             strcat(filename, "/strings/");
             if (!file_exists(filename))
+            {
 #ifdef _WINDOWS
                 _mkdir(filename);
 #else
                 mkdir(filename, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IXGRP);
 #endif
+            }
             strcat(filename, (char *)v1->val.ptr);
             if ((fp = fopen(filename, "r")) == NULL)
             {

--- a/vme/src/dilinst.cpp
+++ b/vme/src/dilinst.cpp
@@ -499,11 +499,13 @@ void dilfi_stora(class dilprg *p)
                     }
                     strcat(filename, "/units/");
                     if (!file_exists(filename))
+                    {
 #ifdef _WINDOWS
                         _mkdir(filename);
 #else
                         mkdir(filename, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IXGRP);
 #endif
+                    }
                     strcat(filename, (char *)v2->val.ptr);
 
                     if (v3->val.num >= 1)

--- a/vme/src/files.cpp
+++ b/vme/src/files.cpp
@@ -448,10 +448,16 @@ int load_string(char *filename, char **file_str)
     {
 #ifndef _WINDOWS
         if (nread > (unsigned int)statbuf.st_blksize)
+        {
             rt = read(input, temp, statbuf.st_blksize);
+        }
         else
-#endif
+        {
             rt = read(input, temp, nread);
+        }
+#else
+        rt = read(input, temp, nread);
+#endif
         temp = temp + rt;
         nread = nread - rt;
     }
@@ -474,17 +480,21 @@ int save_string(char *filename, char **file_str, char *opp)
         return (FILE_NOT_SAVED);
 
     if (opp[0] == 'w')
+    {
 #ifdef _WINDOWS
         output = open(filename, O_WRONLY | O_CREAT, S_IREAD | S_IWRITE);
 #else
         output = open(filename, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
 #endif
+    }
     else
+    {
 #ifdef _WINDOWS
         output = open(filename, O_WRONLY | O_CREAT | O_APPEND, S_IREAD | S_IWRITE);
 #else
         output = open(filename, O_WRONLY | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
 #endif
+    }
     if (!output)
         return (FILE_NOT_CREATED);
     stat(filename, &statbuf);
@@ -506,7 +516,6 @@ int save_string(char *filename, char **file_str, char *opp)
             nwrite = nwrite - statbuf.st_blksize;
         }
         else
-#endif
         {
             size_t mstmp = write(output, temp, nwrite);
             if (mstmp < 1)
@@ -516,6 +525,15 @@ int save_string(char *filename, char **file_str, char *opp)
             }
             nwrite = nwrite - nwrite;
         }
+#else
+        size_t mstmp = write(output, temp, nwrite);
+        if (mstmp < 1)
+        {
+            slog(LOG_ALL, 0, "ERROR: Unexpected bytes written %d in save string", mstmp);
+            assert(FALSE);
+        }
+        nwrite = nwrite - nwrite;
+#endif
     }
 
     close(output);

--- a/vme/src/hook.cpp
+++ b/vme/src/hook.cpp
@@ -208,10 +208,14 @@ int cHookNative::read(void *buf, int count)
         {
 #ifdef _WINDOWS
             if (WSAGetLastError() == WSAEWOULDBLOCK || WSAGetLastError() == WSAEINTR)
+            {
                 return 0;
+            }
 #else
             if (errno == EWOULDBLOCK)
+            {
                 return 0;
+            }
 #endif
             slog(LOG_ALL, 0, "Read from socket %d error %d", fd, errno);
             Unhook();

--- a/vme/src/mplex2/ClientConnector.cpp
+++ b/vme/src/mplex2/ClientConnector.cpp
@@ -477,11 +477,14 @@ void cConHook::Input(int nFlags)
         {
 #if defined(_WINDOWS)
             if (WSAGetLastError() == WSAEWOULDBLOCK || WSAGetLastError() == WSAEINTR)
+            {
                 return;
-
+            }
 #else
             if ((errno == EWOULDBLOCK) || (errno == EAGAIN))
+            {
                 return;
+            }
 #endif
 
             Close(TRUE);
@@ -877,18 +880,20 @@ void cConHook::StripHTML(char *dest, const char *src)
                     // strcpy(dest, aTag); TAIL(dest);
                     // strcpy(dest, "||"); TAIL(dest);
 
-
                     // If the tag has 'bars' it's a health update
                     l = getHTMLValue("bars", aTag, buf, sizeof(buf) - 1);
 
                     if (l != 0)
                     {
-                        strcpy(dest, "||"); TAIL(dest);
-                        strcpy(dest, buf); TAIL(dest);
-                        strcpy(dest, "||"); TAIL(dest);
+                        strcpy(dest, "||");
+                        TAIL(dest);
+                        strcpy(dest, buf);
+                        TAIL(dest);
+                        strcpy(dest, "||");
+                        TAIL(dest);
 
                         // KYLE: buf will have the hp,mp,ep
-                        // remove the three debug lines above, parse the string, and 
+                        // remove the three debug lines above, parse the string, and
                         // output mud protocol codes
                         //
                         continue;
@@ -898,12 +903,15 @@ void cConHook::StripHTML(char *dest, const char *src)
 
                     if (l != 0)
                     {
-                        strcpy(dest, "||"); TAIL(dest);
-                        strcpy(dest, buf); TAIL(dest);
-                        strcpy(dest, "||"); TAIL(dest);
+                        strcpy(dest, "||");
+                        TAIL(dest);
+                        strcpy(dest, buf);
+                        TAIL(dest);
+                        strcpy(dest, "||");
+                        TAIL(dest);
 
                         // KYLE: buf will have the visible exits
-                        // remove the three debug lines above, parse the string, and 
+                        // remove the three debug lines above, parse the string, and
                         // output mud protocol codes
                         //
                         continue;

--- a/vme/src/structs.cpp
+++ b/vme/src/structs.cpp
@@ -77,9 +77,13 @@ char_data::~char_data(void)
 {
 #ifdef DMSERVER
     if (money)
+    {
         FREE(money);
+    }
     if (last_attacker)
+    {
         FREE(last_attacker);
+    }
 #endif
     g_world_nochars--;
 }
@@ -525,10 +529,14 @@ unit_data::~unit_data(void)
         FREE(key);
 #ifdef DMSERVER
     while (UNIT_FUNC(this))
+    {
         destroy_fptr(this, UNIT_FUNC(this)); /* Unlinks, no free */
+    }
 
     while (UNIT_AFFECTED(this))
+    {
         unlink_affect(UNIT_AFFECTED(this));
+    }
 #endif
 
     /* Call functions of the unit which have any data                     */

--- a/vme/src/vmelimits.cpp
+++ b/vme/src/vmelimits.cpp
@@ -307,7 +307,9 @@ void advance_level(class unit_data *ch)
 
 #ifdef NOBLE
     if (IS_NOBLE(ch))
+    {
         return;
+    }
 #endif
 
     send_to_char("You raise a level!<br/>", ch);
@@ -339,9 +341,11 @@ void advance_level(class unit_data *ch)
 
 #ifdef NOBLE
     if (IS_NOBLE(ch))
+    {
         send_to_char("You become a noble, seek audience "
                      "with King Welmar.<br/>",
                      ch);
+    }
 
 #endif
 }


### PR DESCRIPTION
Manually fix a couple of places clang-tidy cannot handle
Added script to run to execute clang tidy

Pre-req is for clang-tidy-12 to be installed on ubuntu `sudo apt-get install clang-tidy-12`

Just execute the script for the top level of DikuMUD3

I've tested this multiple times on Fedora and Ubuntu 20.04  and checked the results and it looks good to me. The only thing to be aware of is near single line `#defines`, it doesn't handle them well, I think I fixed them all - eg look out for below
```
if(foo)
    do_blah();
else
#ifdef FRIDAY
    do_friday();
#else 
    do_tuesday();
#endif 
```

I use meld for reviewing changes locally before staging, it is available on windows: https://meldmerge.org/
On linux I run before staging (but you can pass refspecs)
`git difftool --dir-diff`

Not sure about configure meld as default git diff on windows - but I found this
```
git config --global merge.tool meld
git config --global diff.tool meld
git config --global mergetool.meld.path “C:\Program Files (x86)\Meld\meld\meld.exe”
```

