### PR TITLE
Replacing s*printf like calls with boost format

### DIFF
--- a/vme/src/act_wizard.cpp
+++ b/vme/src/act_wizard.cpp
@@ -54,18 +54,10 @@ void do_timewarp(class unit_data *ch, char *argument, const struct command_info 
 
 void do_users(class unit_data *ch, char *argument, const struct command_info *cmd)
 {
-    char *buf = nullptr;
-    int cur_size = 1024;
-
     class descriptor_data *d;
-    char tmp[256];
-    int len, users = 0;
+    int users = 0;
 
-    if (buf == nullptr)
-        CREATE(buf, char, cur_size);
-
-    strcpy(buf, "<u>Connections:</u><br/>");
-    len = strlen(buf);
+    std::string msg{"<u>Connections:</u><br/>"};
     /*
        <I%3d/%3d> immort lvl / wizi
        < %3d>     mortal vlvl
@@ -81,57 +73,34 @@ void do_users(class unit_data *ch, char *argument, const struct command_info *cm
             if (IS_IMMORTAL(d->character))
             {
                 /* an immortal character */
-                snprintf(tmp,
-                         sizeof(tmp),
-                         "&lt;I%3d/%3d&gt; %-16s %-10s [%c %4d %-3s %s]<br/>",
-                         CHAR_LEVEL(CHAR_ORIGINAL(d->character)),
-                         UNIT_MINV(CHAR_ORIGINAL(d->character)),
-                         UNIT_NAME(CHAR_ORIGINAL(d->character)),
-                         descriptor_is_playing(d) ? "Playing" : "Menu",
-                         g_cServerConfig.FromLAN(d->host) ? 'L' : 'W',
-                         d->nPort,
-                         d->nLine == 255 ? "---" : itoa(d->nLine),
-                         d->host);
+                msg += diku::format_to_str("&lt;I%3d/%3d&gt; %-16s %-10s [%c %4d %-3s %s]<br/>",
+                                           CHAR_LEVEL(CHAR_ORIGINAL(d->character)),
+                                           UNIT_MINV(CHAR_ORIGINAL(d->character)),
+                                           UNIT_NAME(CHAR_ORIGINAL(d->character)),
+                                           descriptor_is_playing(d) ? "Playing" : "Menu",
+                                           g_cServerConfig.FromLAN(d->host) ? 'L' : 'W',
+                                           d->nPort,
+                                           d->nLine == 255 ? "---" : itoa(d->nLine),
+                                           d->host);
             }
             else
             {
                 /* a mortal character */
-                snprintf(tmp,
-                         sizeof(tmp),
-                         "&lt; %6d%c&gt; %-16s %-10s [%c %4d %-3s %s]<br/>",
-                         PC_VIRTUAL_LEVEL(CHAR_ORIGINAL(d->character)),
-                         UNIT_MINV(CHAR_ORIGINAL(d->character)) ? '*' : ' ',
-                         UNIT_NAME(CHAR_ORIGINAL(d->character)),
-                         descriptor_is_playing(d) ? "Playing" : "Menu",
-                         g_cServerConfig.FromLAN(d->host) ? 'L' : 'W',
-                         d->nPort,
-                         d->nLine == 255 ? "---" : itoa(d->nLine),
-                         d->host);
+                msg += diku::format_to_str("&lt; %6d%c&gt; %-16s %-10s [%c %4d %-3s %s]<br/>",
+                                           PC_VIRTUAL_LEVEL(CHAR_ORIGINAL(d->character)),
+                                           UNIT_MINV(CHAR_ORIGINAL(d->character)) ? '*' : ' ',
+                                           UNIT_NAME(CHAR_ORIGINAL(d->character)),
+                                           descriptor_is_playing(d) ? "Playing" : "Menu",
+                                           g_cServerConfig.FromLAN(d->host) ? 'L' : 'W',
+                                           d->nPort,
+                                           d->nLine == 255 ? "---" : itoa(d->nLine),
+                                           d->host);
             }
-
-            len += strlen(tmp);
-            if (cur_size < len + 1)
-            {
-                cur_size *= 2;
-                RECREATE(buf, char, cur_size);
-            }
-            strcat(buf, tmp);
         }
     }
 
-    snprintf(tmp, sizeof(tmp), "<br/>%d visible players connected.<br/>", users);
-
-    len += strlen(tmp);
-    if (cur_size < len + 1)
-    {
-        cur_size *= 2;
-        RECREATE(buf, char, cur_size);
-    }
-
-    strcat(buf, tmp);
-
-    page_string(CHAR_DESCRIPTOR(ch), buf);
-    FREE(buf);
+    msg += diku::format_to_str("<br/>%d visible players connected.<br/>", users);
+    page_string(CHAR_DESCRIPTOR(ch), msg);
 }
 
 /* Reset the zone in which the char is in! */

--- a/vme/src/act_wstat.h
+++ b/vme/src/act_wstat.h
@@ -2,4 +2,4 @@
 
 void do_wstat(class unit_data *, char *, const struct command_info *);
 void do_wedit(class unit_data *, char *, const struct command_info *);
-char *stat_obj_data(class unit_data *u, struct obj_type_t *obj_data);
+const char *stat_obj_data(class unit_data *u, struct obj_type_t *obj_data);

--- a/vme/src/cmdload.cpp
+++ b/vme/src/cmdload.cpp
@@ -21,6 +21,7 @@
 #include "db.h"
 #include "experience.h"
 #include "files.h"
+#include "formatter.h"
 #include "interpreter.h"
 #include "modify.h"
 #include "reception.h"
@@ -72,9 +73,6 @@ struct cmdload_struct cmdload[] = {{"north", do_move, 0, 0},        {"northeast"
 
 void skill_dump(void)
 {
-    std::string str;
-    char buf[MAX_STRING_LENGTH];
-
     for (int j = 0; j < PROFESSION_MAX; j++)
     {
         std::vector<std::pair<int, std::string>> vect;
@@ -86,20 +84,13 @@ void skill_dump(void)
                 continue;
             }
 
-            str = "";
+            std::string str = diku::format_to_str("%s,%s", g_SkiColl.text[i], spc(20 - strlen(g_SkiColl.text[i])));
 
-            snprintf(buf, sizeof(buf), "%s,%s", g_SkiColl.text[i], spc(20 - strlen(g_SkiColl.text[i])));
-            str.append(buf);
-
-            snprintf(buf,
-                     sizeof(buf),
-                     ".profession %s%s = %s%d\n",
-                     g_professions[j],
-                     spc(12 - strlen(g_professions[j])),
-                     (g_SkiColl.prof_table[i].profession_cost[j] >= 0) ? "+" : "",
-                     g_SkiColl.prof_table[i].profession_cost[j]);
-            str.append(buf);
-
+            str += diku::format_to_str(".profession %s%s = %s%d\n",
+                                       g_professions[j],
+                                       spc(12 - strlen(g_professions[j])),
+                                       (g_SkiColl.prof_table[i].profession_cost[j] >= 0) ? "+" : "",
+                                       g_SkiColl.prof_table[i].profession_cost[j]);
             /*if (g_SkiColl.prof_table[i].min_level > 0)
             {
                 s printf(buf, "restrict level          = %d\n", g_SkiColl.prof_table[i].min_level);

--- a/vme/src/combat.cpp
+++ b/vme/src/combat.cpp
@@ -387,8 +387,6 @@ class unit_data *cCombat::Opponent(int i)
 
 void cCombat::status(const class unit_data *god)
 {
-    int i;
-
     auto msg = diku::format_to_str("Combat Status of '%s':<br/>"
                                    "Combat Speed [%d]  Turn [%d]<br/>"
                                    "Melee Opponent '%s'<br/>"
@@ -399,7 +397,7 @@ void cCombat::status(const class unit_data *god)
                                    CHAR_FIGHTING(pOwner) ? STR(UNIT_NAME(CHAR_FIGHTING(pOwner))) : "NONE",
                                    nNoOpponents);
 
-    for (i = 0; i < nNoOpponents; i++)
+    for (int i = 0; i < nNoOpponents; i++)
     {
         msg += diku::format_to_str("   %s<br/>", STR(UNIT_NAME(pOpponents[i])));
     }

--- a/vme/src/convert.cpp
+++ b/vme/src/convert.cpp
@@ -7,6 +7,7 @@
 #include "affect.h"
 #include "db.h"
 #include "db_file.h"
+#include "formatter.h"
 #include "handler.h"
 #include "nanny.h"
 #include "pcsave.h"
@@ -328,11 +329,10 @@ class unit_data *convert_load_player(char *name)
 
 const char *isodate(struct tm *t)
 {
-    static char buf[200];
+    static std::string isodate;
 
-    snprintf(buf, sizeof(buf), "%04d-%02d-%02d", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday);
-
-    return buf;
+    isodate = diku::format_to_str("%04d-%02d-%02d", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday);
+    return isodate.c_str();
 }
 
 void clist()

--- a/vme/src/dilexp.cpp
+++ b/vme/src/dilexp.cpp
@@ -3223,10 +3223,9 @@ void *threadcallout(void *p)
 
     if (ok)
     {
-        std::string s;
-        s = "./allow/"; // current dir iswhere vme/bin is located, set to bin/allow/
-        s.append(str);
-        slog(LOG_BRIEF, 0, "system('%s'); ", s.c_str());
+        std::string s{"./allow/"}; // current dir iswhere vme/bin is located, set to bin/allow/
+        s += str;
+        slog(LOG_BRIEF, 0, "system('%s'); ", s);
         int rc = ::system((const char *)s.c_str());
 
         if (rc == -1 || WEXITSTATUS(rc) != 0)

--- a/vme/src/eliza.cpp
+++ b/vme/src/eliza.cpp
@@ -9,6 +9,7 @@
 
 #include "db.h"
 #include "files.h"
+#include "formatter.h"
 #include "handler.h"
 #include "interpreter.h"
 #include "main_functions.h"
@@ -585,11 +586,8 @@ void eliza_log(class unit_data *who, const char *str, int comms)
 
     if ((comms < 5) && (idx < MAX_ELIBUF))
     {
-        char tmp[1024];
-
-        snprintf(tmp, sizeof(tmp), "%-12s::  %s\n", UNIT_NAME(who), str);
-
-        buf[idx++] = str_dup(tmp);
+        auto tmp = diku::format_to_str("%-12s::  %s\n", UNIT_NAME(who), str);
+        buf[idx++] = str_dup(tmp.c_str());
         return;
     }
 

--- a/vme/src/main_functions.cpp
+++ b/vme/src/main_functions.cpp
@@ -60,7 +60,7 @@ int g_mud_reboot = 0;   /* reboot the game after a shutdown */
 int g_wizlock = 0;      /* no mortals on now */
 int g_tics = 60;        /* number of tics since boot-time */
 
-char g_world_boottime[64] = ""; /* boottime of world */
+std::string g_world_boottime; /* boottime of world */
 
 /* ******************************************************************* *
  *             main game loop and related stuff                        *

--- a/vme/src/main_functions.h
+++ b/vme/src/main_functions.h
@@ -2,6 +2,8 @@
 
 #include "event.h"
 
+#include <string>
+
 // Prototypes
 void ShowUsage(const char *c);
 void type_validate_64(void);
@@ -18,7 +20,7 @@ void timewarp_end(void *p1, void *p2);
 #ifdef PROFILE
 extern char g_etext;
 #endif
-extern char g_world_boottime[64];
+extern std::string g_world_boottime;
 extern class descriptor_data *g_descriptor_list;
 extern class descriptor_data *g_next_to_process;
 extern eventqueue g_events;

--- a/vme/src/modify.cpp
+++ b/vme/src/modify.cpp
@@ -300,15 +300,13 @@ void show_fields(class unit_data *ch)
 
 void show_structure(const char *structure[], class unit_data *ch)
 {
-    char **c;
-    std::string s;
-
     if (structure == nullptr)
     {
         return;
     }
 
-    for (c = (char **)structure; *c; c++)
+    std::string s;
+    for (char **c = (char **)structure; *c; c++)
     {
         s += diku::format_to_str("%s<br/>", *c);
     }

--- a/vme/src/pcsave.cpp
+++ b/vme/src/pcsave.cpp
@@ -13,6 +13,7 @@
 #include "dilrun.h"
 #include "error.h"
 #include "files.h"
+#include "formatter.h"
 #include "handler.h"
 #include "interpreter.h"
 #include "mobact.h"
@@ -53,16 +54,16 @@ void assign_player_file_index(unit_data *pc)
     }
 }
 
-char *PlayerFileName(const char *pName)
+std::string PlayerFileName(const char *pName)
 {
-    static char Buf[MAX_INPUT_LENGTH + 1 + 512];
-    char TmpBuf[MAX_INPUT_LENGTH + 1];
+    std::string TmpBuf;
 
-    strcpy(TmpBuf, pName);
-    str_lower(TmpBuf);
-    snprintf(Buf, sizeof(Buf), "%s%c/%s", g_cServerConfig.getPlyDir().c_str(), *TmpBuf, TmpBuf);
-
-    return Buf;
+    if (pName)
+    {
+        TmpBuf = pName;
+        str_lower(TmpBuf);
+    }
+    return diku::format_to_str("%s%c/%s", g_cServerConfig.getPlyDir(), *TmpBuf.c_str(), TmpBuf);
 }
 
 /* Return TRUE if exists */
@@ -101,7 +102,7 @@ int delete_inventory(const char *pName)
 /* Return TRUE if deleted */
 int delete_player(const char *pName)
 {
-    if (remove(PlayerFileName(pName)))
+    if (remove(PlayerFileName(pName).c_str()))
     {
         return FALSE;
     }
@@ -123,7 +124,7 @@ sbit32 find_player_id(char *pName)
         return -1;
     }
 
-    pFile = fopen(PlayerFileName(pName), "rb");
+    pFile = fopen(PlayerFileName(pName).c_str(), "rb");
 
     if (pFile == nullptr)
     {
@@ -221,7 +222,7 @@ void save_player_disk(const char *pName, char *pPassword, sbit32 id, int nPlyLen
        crashes, it doesn't garble the player. At least then, the
        old file will remain intact. */
 
-    n = rename(tmp_player_name.c_str(), PlayerFileName(pName));
+    n = rename(tmp_player_name.c_str(), PlayerFileName(pName).c_str());
     assert(n == 0);
 }
 
@@ -484,7 +485,7 @@ class unit_data *load_player(const char *pName)
         return nullptr;
     }
 
-    pFile = fopen(PlayerFileName(pName), "rb");
+    pFile = fopen(PlayerFileName(pName).c_str(), "rb");
     if (pFile == nullptr)
     {
         return nullptr;

--- a/vme/src/pcsave.h
+++ b/vme/src/pcsave.h
@@ -2,7 +2,9 @@
 
 #include "essential.h"
 
-char *PlayerFileName(const char *);
+#include <string>
+
+std::string PlayerFileName(const char *);
 int delete_inventory(const char *pName);
 int delete_player(const char *);
 int find_player_id(char *pName);

--- a/vme/src/reception.cpp
+++ b/vme/src/reception.cpp
@@ -346,13 +346,13 @@ void send_saves(class unit_data *parent, class unit_data *unit)
     }
 }
 
-char *ContentsFileName(const char *pName)
+const char *ContentsFileName(const char *pName)
 {
-    static char Buf[MAX_INPUT_LENGTH + 1];
+    static std::string Buf;
 
-    snprintf(Buf, sizeof(Buf), "%s.inv", PlayerFileName(pName));
+    Buf = PlayerFileName(pName) + ".inv";
 
-    return Buf;
+    return Buf.c_str();
 }
 
 /* Save all units inside 'unit' in the blk_file 'bf' as uncompressed  */

--- a/vme/src/reception.h
+++ b/vme/src/reception.h
@@ -2,7 +2,7 @@
 
 #include "essential.h"
 
-char *ContentsFileName(const char *);
+const char *ContentsFileName(const char *);
 class unit_data *restore_all_unit(char *filename, unit_data *udest);
 int diff(char *ref, ubit32 reflen, char *obj, int objlen, char *dif, int diflen, ubit32 crc);
 int patch(char *ref, ubit32 reflen, char *dif, int diflen, char *res, int reslen, ubit32 crc);

--- a/vme/src/skills.cpp
+++ b/vme/src/skills.cpp
@@ -1051,49 +1051,37 @@ bool pairISCompare(const std::pair<int, std::string> &firstElem, const std::pair
 
 void ability_dump(void)
 {
-    std::string str;
-    char buf[MAX_STRING_LENGTH];
-
     for (int j = 0; j < PROFESSION_MAX; j++)
     {
         std::vector<std::pair<int, std::string>> vect;
 
         for (int i = 0; i < ABIL_TREE_MAX; i++)
         {
-            str = "";
+            auto str = diku::format_to_str("%s,%s", g_AbiColl.text[i], spc(20 - strlen(g_AbiColl.text[i])));
 
-            snprintf(buf, sizeof(buf), "%s,%s", g_AbiColl.text[i], spc(20 - strlen(g_AbiColl.text[i])));
-            str.append(buf);
-
-            snprintf(buf,
-                     sizeof(buf),
-                     ".profession %s%s = %s%d\n",
-                     g_professions[j],
-                     spc(12 - strlen(g_professions[j])),
-                     (g_AbiColl.prof_table[i].profession_cost[j] >= 0) ? "+" : "",
-                     g_AbiColl.prof_table[i].profession_cost[j]);
-            str.append(buf);
+            str += diku::format_to_str(".profession %s%s = %s%d\n",
+                                       g_professions[j],
+                                       spc(12 - strlen(g_professions[j])),
+                                       (g_AbiColl.prof_table[i].profession_cost[j] >= 0) ? "+" : "",
+                                       g_AbiColl.prof_table[i].profession_cost[j]);
 
             vect.push_back(std::make_pair(g_AbiColl.prof_table[i].profession_cost[j], str));
 
+            // TODO This looks broken str is never used again in the old code
             if (g_AbiColl.prof_table[i].min_level > 0)
             {
-                snprintf(buf, sizeof(buf), "restrict level          = %d\n", g_AbiColl.prof_table[i].min_level);
-                str.append(buf);
+                str += diku::format_to_str("restrict level          = %d\n", g_AbiColl.prof_table[i].min_level);
             }
 
             for (int j = 0; j < ABIL_TREE_MAX; j++)
             {
                 if (g_AbiColl.prof_table[i].min_abil[j] > 0)
                 {
-                    snprintf(buf,
-                             sizeof(buf),
-                             "restrict %s%s    = %s%d\n",
-                             g_AbiColl.text[j],
-                             spc(12 - strlen(g_professions[j])),
-                             (g_AbiColl.prof_table[i].min_abil[j] >= 0) ? "+" : "",
-                             g_AbiColl.prof_table[i].min_abil[j]);
-                    str.append(buf);
+                    str += diku::format_to_str("restrict %s%s    = %s%d\n",
+                                               g_AbiColl.text[j],
+                                               spc(12 - strlen(g_professions[j])),
+                                               (g_AbiColl.prof_table[i].min_abil[j] >= 0) ? "+" : "",
+                                               g_AbiColl.prof_table[i].min_abil[j]);
                 }
             }
         }
@@ -1492,9 +1480,6 @@ static void weapon_init(void)
 
 void weapon_dump(void)
 {
-    std::string str;
-    char buf[MAX_STRING_LENGTH];
-
     for (int j = 0; j < PROFESSION_MAX; j++)
     {
         std::vector<std::pair<int, std::string>> vect;
@@ -1506,19 +1491,13 @@ void weapon_dump(void)
                 continue;
             }
 
-            str = "";
+            auto str = diku::format_to_str("%s,%s", g_WpnColl.text[i], spc(20 - strlen(g_WpnColl.text[i])));
 
-            snprintf(buf, sizeof(buf), "%s,%s", g_WpnColl.text[i], spc(20 - strlen(g_WpnColl.text[i])));
-            str.append(buf);
-
-            snprintf(buf,
-                     sizeof(buf),
-                     ".profession %s%s = %s%d\n",
-                     g_professions[j],
-                     spc(12 - strlen(g_professions[j])),
-                     (g_WpnColl.prof_table[i].profession_cost[j] >= 0) ? "+" : "",
-                     g_WpnColl.prof_table[i].profession_cost[j]);
-            str.append(buf);
+            str += diku::format_to_str(".profession %s%s = %s%d\n",
+                                       g_professions[j],
+                                       spc(12 - strlen(g_professions[j])),
+                                       (g_WpnColl.prof_table[i].profession_cost[j] >= 0) ? "+" : "",
+                                       g_WpnColl.prof_table[i].profession_cost[j]);
 
             vect.push_back(std::make_pair(g_WpnColl.prof_table[i].profession_cost[j], str));
 

--- a/vme/src/spell_parser.cpp
+++ b/vme/src/spell_parser.cpp
@@ -8,6 +8,7 @@
 #include "db.h"
 #include "dilrun.h"
 #include "files.h"
+#include "formatter.h"
 #include "handler.h"
 #include "interpreter.h"
 #include "justice.h"
@@ -939,8 +940,6 @@ static void spell_init(void)
 
 void spell_dump(void)
 {
-    std::string str;
-
     for (int j = 0; j < PROFESSION_MAX; j++)
     {
         std::vector<std::pair<int, std::string>> vect;
@@ -952,7 +951,7 @@ void spell_dump(void)
                 continue;
             }
 
-            str = diku::format_to_str("%s,%s", g_SplColl.text[i], spc(30 - strlen(g_SplColl.text[i])));
+            std::string str = diku::format_to_str("%s,%s", g_SplColl.text[i], spc(30 - strlen(g_SplColl.text[i])));
 
             str += diku::format_to_str(".profession %s%s = %s%d\n",
                                        g_professions[j],

--- a/vme/src/textutil.cpp
+++ b/vme/src/textutil.cpp
@@ -8,6 +8,7 @@
 #include "textutil.h"
 
 #include "common.h"
+#include "formatter.h"
 #include "slog.h"
 #include "structs.h"
 
@@ -66,6 +67,19 @@ int str_lower(char *s)
     }
 
     return l;
+}
+
+int str_lower(std::string &s)
+{
+    for (size_t i = 0; i < s.length(); ++i)
+    {
+        if (isupper(s[i]))
+        {
+            s[i] = tolower(s[i]);
+        }
+    }
+
+    return static_cast<int>(s.length());
 }
 
 int str_upper(char *s)
@@ -149,24 +163,24 @@ char *spc(int n)
  *  of the integer 'n'
  *  I've made it the easy way :)
  */
-char *itoa(int n)
+const char *itoa(int n)
 {
-    static char buf[32]; /* 32 digits can even cope with 64 bit ints */
+    static std::string buf; /* 32 digits can even cope with 64 bit ints */
 
-    snprintf(buf, sizeof(buf), "%d", n);
-    return buf;
+    buf = diku::format_to_str("%d", n);
+    return buf.c_str();
 }
 
 /*  Return a pointer to the string containing the ascii reresentation
  *  of the integer 'n'
  *  I've made it the easy way :)
  */
-char *ltoa(long n)
+const char *ltoa(long n)
 {
-    static char buf[32]; /* 32 digits can even cope with 64 bit ints */
+    static std::string buf; /* 32 digits can even cope with 64 bit ints */
 
-    snprintf(buf, sizeof(buf), "%ld", n);
-    return buf;
+    buf = diku::format_to_str("%ld", n);
+    return buf.c_str();
 }
 
 /*  STR Convention: "str_" [n] [c] <meaning>
@@ -1765,11 +1779,11 @@ int substHTMLTagClass(const char *pOldTag, const char *pAttr, const char *pNewVa
 // given the attribute colorstr return <div class='colorstr'>. Dont make colorstr too insanely long.
 const char *divcolor(const char *colorstr)
 {
-    static char buf[256];
+    static std::string buf;
 
-    snprintf(buf, sizeof(buf), "<div class='%s'>", colorstr);
+    buf = diku::format_to_str("<div class='%s'>", colorstr);
 
-    return buf;
+    return buf.c_str();
 }
 
 // Encode str to JSON encoding (format X)

--- a/vme/src/textutil.h
+++ b/vme/src/textutil.h
@@ -33,6 +33,7 @@ const char *is_name_raw(const char *arg, char const *const *names); // MS2020 co
 char *is_name(char *arg, char const *const *names);                 // arg will get double spaces zapped
 
 int str_lower(char *s);
+int str_lower(std::string &s);
 int str_upper(char *s);
 int str_lower(const char *s, char *d, int nBufSize);
 
@@ -40,8 +41,8 @@ char *spc(int n);
 char *str_repeatchar(int n, char c);
 
 char *str_line(const char *, char *);
-char *itoa(int n);
-char *ltoa(long n);
+const char *itoa(int n);
+const char *ltoa(long n);
 int str_ccmp(const char *s, const char *d);
 int str_nccmp(const char *s, const char *d, int n);
 char *str_dup(const char *source);

--- a/vme/src/weather.cpp
+++ b/vme/src/weather.cpp
@@ -15,8 +15,6 @@
 #include "structs.h"
 #include "utils.h"
 
-#include <cstdio>
-#include <cstring>
 #include <ctime>
 
 int g_sunlight = SUN_SET;                     /* And how much sun. */
@@ -343,14 +341,11 @@ void weather_and_time_event(void *p1, void *p2)
 /* reset the time in the game from file */
 void boot_time_and_weather(void)
 {
-    struct time_info_data time_info;
     g_tBootTime = time(nullptr);
-    char *p = ctime(&g_tBootTime);
-    p[strlen(p) - 1] = '\0';
+    g_world_boottime = ctime(&g_tBootTime);
+    g_world_boottime.erase(g_world_boottime.length() - 1);
 
-    snprintf(g_world_boottime, sizeof(g_world_boottime), "%s", p);
-
-    time_info = mud_time_passed(time(nullptr), g_beginning_of_time);
+    struct time_info_data time_info = mud_time_passed(time(nullptr), g_beginning_of_time);
 
     if (time_info.hours == 5)
     {

--- a/vme/src/zon_basis.h
+++ b/vme/src/zon_basis.h
@@ -1,8 +1,8 @@
 #pragma once
 
-int system_check(class unit_data *pc, char *buf);
+int system_check(class unit_data *pc, const char *buf);
 void basis_boot(void);
-void execute_append(class unit_data *pc, char *str);
+void execute_append(class unit_data *pc, const char *str);
 int log_object(struct spec_arg *sarg);
 int error_rod(struct spec_arg *sarg);
 int info_rod(struct spec_arg *sarg);


### PR DESCRIPTION
Part 2.9 of 3
Refactor internals of some functions to use std::string
Refactor most of the complicated sprintf usages.