### PR TITLE
Make diku::format_to_str noexcept

### DIFF
--- a/vme/src/CMakeLists.txt
+++ b/vme/src/CMakeLists.txt
@@ -76,6 +76,7 @@ set(VME_SRCS
         skills.cpp skills.h
         slime.cpp slime.h
         slog.h
+        slog_raw.cpp slog_raw.h
         spec_assign.cpp spec_assign.h
         spec_procs.cpp spec_procs.h
         spell_parser.cpp spell_parser.h
@@ -96,7 +97,8 @@ set(VME_SRCS
         zon_basis.cpp zon_basis.h
         zon_wiz.cpp zon_wiz.h
         zone_reset.cpp zone_reset.h
-        )
+ szonelog_raw.cpp szonelog_raw.h
+)
 
 # Add all sources to a library file so we can link with other projects and test suites
 add_library(vme_objs STATIC ${VME_SRCS})

--- a/vme/src/error.h
+++ b/vme/src/error.h
@@ -2,6 +2,8 @@
 
 #include "slog.h"
 
+#define HERE __FILE__, __LINE__
+
 /**
  * Public call to error(). Because this uses boost::format internally std::string
  * can be formatted with %s specifier and user defined types can also be printed
@@ -29,9 +31,7 @@ void error(const char *file, int line, const std::string &fmt, ParamPack &&...pa
     std::string str;
     if constexpr (sizeof...(pack) != 0)
     {
-        boost::format format(fmt);
-        diku::format(format, pack...);
-        str = format.str();
+        str = diku::format_to_str(fmt.c_str(), pack...);
     }
     else
     {

--- a/vme/src/mplex2/CMakeLists.txt
+++ b/vme/src/mplex2/CMakeLists.txt
@@ -16,6 +16,7 @@ set(MPLEX_SRCS
         ../membug.cpp ../membug.h
         ../protocol.cpp ../protocol.h
         ../queue.cpp ../queue.h
+        ../slog_raw.cpp ../slog_raw.h
         ../textutil.cpp ../textutil.h
         ../utility.cpp ../utility.h
         )

--- a/vme/src/slog.h
+++ b/vme/src/slog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "formatter.h"
+#include "slog_raw.h"
 #include "utility.h"
 
 #include <boost/format.hpp>
@@ -24,9 +25,7 @@ void slog(log_level level, ubit8 wizinv_level, const std::string &fmt, ParamPack
     std::string formatted_text;
     if constexpr (sizeof...(pack) != 0)
     {
-        boost::format format(fmt);
-        diku::format(format, pack...);
-        formatted_text = format.str();
+        formatted_text = diku::format_to_str(fmt.c_str(), pack...);
     }
     else
     {
@@ -34,9 +33,6 @@ void slog(log_level level, ubit8 wizinv_level, const std::string &fmt, ParamPack
     }
 
     std::string buf;
-    time_t now = time(nullptr);
-    std::string tmstr = ctime(&now);
-    tmstr.erase(tmstr.length() - 1);
 
     if (wizinv_level > 0)
     {
@@ -44,29 +40,5 @@ void slog(log_level level, ubit8 wizinv_level, const std::string &fmt, ParamPack
     }
     buf += formatted_text;
 
-    /* 5 == " :: \n";  24 == tmstr (Tue Sep 20 18:41:23 1994) */
-    static uint32_t log_size = 0;
-    log_size += buf.length() + 5 + 24;
-
-    if (log_size > 40'000'000) /* 40 meg is indeed a very big logfile! */
-    {
-        fprintf(g_log_file_fd, "Log-file insanely big!  Going down.\n");
-        std::terminate(); // Dont use error, it calls syslog!!! *grin*
-    }
-
-    fprintf(g_log_file_fd, "%s :: %s\n", tmstr.c_str(), buf.c_str());
-    fflush(g_log_file_fd);
-
-    static uint8_t idx = 0;
-    if (level > LOG_OFF)
-    {
-        g_log_buf[idx].setLevel(level);
-        g_log_buf[idx].setWizInvLevel(wizinv_level);
-        g_log_buf[idx].setString(buf);
-
-        idx++;
-        idx %= MAXLOG; /* idx = 1 .. MAXLOG-1 */
-
-        g_log_buf[idx].clearString();
-    }
+    slog_raw(level, wizinv_level, buf);
 }

--- a/vme/src/slog_raw.cpp
+++ b/vme/src/slog_raw.cpp
@@ -1,0 +1,38 @@
+#include "slog_raw.h"
+
+#include "utility.h"
+
+#include <exception>
+
+void slog_raw(log_level level, ubit8 wizinv_level, const std::string &msg)
+{
+    time_t now = time(nullptr);
+    std::string tmstr = ctime(&now);
+    tmstr.erase(tmstr.length() - 1);
+
+    /* 5 == " :: \n";  24 == tmstr (Tue Sep 20 18:41:23 1994) */
+    static uint32_t log_size = 0;
+    log_size += msg.length() + 5 + 24;
+
+    if (log_size > 40'000'000) /* 40 meg is indeed a very big logfile! */
+    {
+        fprintf(g_log_file_fd, "Log-file insanely big!  Going down.\n");
+        std::terminate(); // Dont use error, it calls syslog!!! *grin*
+    }
+
+    fprintf(g_log_file_fd, "%s :: %s\n", tmstr.c_str(), msg.c_str());
+    fflush(g_log_file_fd);
+
+    static uint8_t idx = 0;
+    if (level > LOG_OFF)
+    {
+        g_log_buf[idx].setLevel(level);
+        g_log_buf[idx].setWizInvLevel(wizinv_level);
+        g_log_buf[idx].setString(msg);
+
+        idx++;
+        idx %= MAXLOG; /* idx = 1 .. MAXLOG-1 */
+
+        g_log_buf[idx].clearString();
+    }
+}

--- a/vme/src/slog_raw.h
+++ b/vme/src/slog_raw.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "essential.h"
+
+#include <string>
+
+void slog_raw(log_level level, ubit8 wizinv_level, const std::string &msg);

--- a/vme/src/szonelog_raw.cpp
+++ b/vme/src/szonelog_raw.cpp
@@ -1,0 +1,35 @@
+#include "szonelog_raw.h"
+
+#include "config.h"
+#include "files.h"
+#include "formatter.h"
+#include "slog.h"
+#include "structs.h"
+
+void szonelog_raw(const zone_type *zone, const std::string &msg)
+{
+    if (zone == nullptr)
+    {
+        slog(LOG_ALL, 0, "%s", msg);
+        return;
+    }
+
+    slog(LOG_ALL, 0, "%s/%s", zone->name, msg);
+
+    auto filename = diku::format_to_str("%s%s.err", g_cServerConfig.getZoneDir(), zone->filename);
+
+    FILE *f = fopen_cache(filename, "a");
+    if (f == nullptr)
+    {
+        slog(LOG_ALL, 0, "Unable to append to zonelog '%s'", filename);
+    }
+    else
+    {
+        time_t now = time(nullptr);
+        char *tmstr = ctime(&now);
+
+        tmstr[strlen(tmstr) - 1] = '\0';
+
+        fprintf(f, "%s :: %s\n", tmstr, msg.c_str());
+    }
+}

--- a/vme/src/szonelog_raw.h
+++ b/vme/src/szonelog_raw.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <string>
+
+class zone_type;
+void szonelog_raw(const zone_type *zone, const std::string &msg);

--- a/vme/src/utility.h
+++ b/vme/src/utility.h
@@ -20,7 +20,6 @@
 
 /* in game log stuff below */
 #define MAXLOG 10
-#define HERE __FILE__, __LINE__
 
 class log_buffer
 {


### PR DESCRIPTION
Turn off boost::formats too many args throw

Make format_to_str() noexcept which means that we do not expect any
exceptions from in it but if one does happen std::terminate will be
called

Created some slog/szonelog raw functions that are compiled and not
templated so that they can be called from the the formating templates

Added try/catch to format_to_str so log any other exceptions and
even return default message if things fo wrong.