### PR TITLE
Unit testing for account.cpp and weather.cpp

### DIFF
--- a/unit_tests/.gitignore
+++ b/unit_tests/.gitignore
@@ -1,0 +1,7 @@
+*.info
+defcomp_report/
+mplex_report/
+pp_report/
+vmc_report/
+vme_report/
+

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -7,8 +7,11 @@ set(TEST_RUN_ARGS "")
 add_executable(vme_unit_tests
         vme_main.cpp
         CServerConfiguration_tests.cpp
-        color_type_tests.cpp
+        FixtureBase.cpp FixtureBase.h
+        account_cpp_tests.cpp
         cNamelist_tests.cpp
+        color_type_tests.cpp
+        weather_cpp_tests.cpp
         )
 target_link_options(vme_unit_tests PUBLIC -Wl,-zmuldefs)
 target_compile_definitions(vme_unit_tests

--- a/unit_tests/CServerConfiguration_tests.cpp
+++ b/unit_tests/CServerConfiguration_tests.cpp
@@ -1,8 +1,8 @@
 #define BOOST_TEST_MODULE "CServerConfiguration Unit Tests"
+#include "FixtureBase.h"
 #include "config.h"
 #include "db.h"
 #include "diku_exception.h"
-#include "utility.h"
 
 #include <cstdarg>
 #include <cstring>
@@ -10,10 +10,11 @@
 
 #include <boost/test/unit_test.hpp>
 
-struct CServerConfiguration_Fixture
+struct CServerConfiguration_Fixture : public unit_tests::FixtureBase
 {
     static const std::string server_config;
     CServerConfiguration_Fixture()
+        : FixtureBase()
     {
         // No way to suppress the warning from tempnam because its hardcoded into lib
         // so we'll do it here it's only a unit test
@@ -24,15 +25,8 @@ struct CServerConfiguration_Fixture
 
         std::ofstream strm(fake_server_config_filename);
         strm << server_config;
-
-        // Redirect away application logging to tmp file
-        g_log_file_fd = tmpfile();
     }
-    ~CServerConfiguration_Fixture()
-    {
-        remove(fake_server_config_filename.c_str());
-        fclose(g_log_file_fd);
-    }
+    ~CServerConfiguration_Fixture() { remove(fake_server_config_filename.c_str()); }
     std::string fake_server_config_filename;
 };
 

--- a/unit_tests/FixtureBase.cpp
+++ b/unit_tests/FixtureBase.cpp
@@ -1,0 +1,22 @@
+#include "FixtureBase.h"
+
+#include "OutputCapture.h"
+#include "utility.h"
+
+namespace unit_tests
+{
+FixtureBase::FixtureBase()
+{
+    OutputCapture::EnableOutputCapture();
+
+    // Redirect away application logging to tmp file
+    g_log_file_fd = tmpfile();
+}
+
+FixtureBase::~FixtureBase()
+{
+    fclose(g_log_file_fd);
+    OutputCapture::Instance()->Clear();
+}
+
+} // namespace unit_tests

--- a/unit_tests/FixtureBase.h
+++ b/unit_tests/FixtureBase.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace unit_tests
+{
+struct FixtureBase
+{
+    FixtureBase();
+    virtual ~FixtureBase();
+};
+} // namespace unit_tests

--- a/unit_tests/account_cpp_tests.cpp
+++ b/unit_tests/account_cpp_tests.cpp
@@ -1,0 +1,979 @@
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "cert-err58-cpp"
+#include "../vme/include/vme.h"
+#include "FixtureBase.h"
+#include "OutputCapture.h"
+#include "account.h"
+#include "config.h"
+#include "db.h"
+#include "formatter.h"
+#include "structs.h"
+#include "utils.h"
+
+#include <cstdarg>
+#include <fstream>
+
+#include <boost/test/data/monomorphic.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+
+struct AccountCPPFixture : public unit_tests::FixtureBase
+{
+    AccountCPPFixture()
+        : FixtureBase()
+    {
+        chdir("../vme/src/bin");
+
+        // Boot some global vars needed by these tests
+        std::string config("../etc/server.cfg");
+        g_cServerConfig.Boot(config.data());
+        g_cServerConfig.enableAccounting();
+        g_cAccountConfig.Boot();
+
+        god = std::unique_ptr<pc_data>(dynamic_cast<pc_data *>(new_unit_data(UNIT_ST_PC)));
+        god->names.AppendName("Thor");
+
+        whom = std::unique_ptr<pc_data>(dynamic_cast<pc_data *>(new_unit_data(UNIT_ST_PC)));
+        whom->names.AppendName("Bilbo");
+
+        npc = std::unique_ptr<npc_data>(dynamic_cast<npc_data *>(new_unit_data(UNIT_ST_NPC)));
+        npc->names.AppendName("Red Shirt 1");
+
+        // Booting the server config and account config create log messsage so start with clean slate
+        unit_tests::OutputCapture::Instance()->Clear();
+    }
+
+    ~AccountCPPFixture() = default;
+
+    std::unique_ptr<pc_data> god{};
+    std::unique_ptr<pc_data> whom{};
+    std::unique_ptr<npc_data> npc{};
+};
+
+BOOST_FIXTURE_TEST_SUITE(Account_Public_Funcs_Suite, AccountCPPFixture)
+
+BOOST_AUTO_TEST_SUITE(Account_Flatrate_Change_Suite)
+
+#if 0
+BOOST_AUTO_TEST_CASE(all_nulls_test)
+{
+    BOOST_TEST(false);
+    BOOST_TEST_MESSAGE("The null test below should ideally work");
+    //    BOOST_CHECK_NO_THROW(account_flatrate_change(nullptr, nullptr, 0));
+    (void)0;
+}
+#endif
+
+/**
+ * Days = 20
+ * Flatrate = now() + 10000
+ */
+BOOST_AUTO_TEST_CASE(days_gt_zero_flatrate_gt_now)
+{
+    sbit32 days = 20;
+    time_t now = time(nullptr);
+    whom->account.flatrate = now + 10000;
+
+    const sbit32 expected_flatrate = whom->account.flatrate + (days * SECS_PER_REAL_DAY);
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_flatrate_change(god.get(), whom.get(), days);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(whom->account.flatrate == expected_flatrate);
+
+    const auto &slog = unit_tests::OutputCapture::Instance()->getSLogData();
+    BOOST_TEST(slog.m_level == LOG_ALL);
+    BOOST_TEST(slog.m_wiz_inv_level == 255);
+    BOOST_TEST(slog.m_fmt == "%s change flatrate with %d on account %s.");
+    BOOST_TEST(slog.m_message == "Thor change flatrate with 20 on account Bilbo.");
+
+    const auto &account_log = unit_tests::OutputCapture::Instance()->getAccountLogData();
+    BOOST_TEST(account_log.m_action == 'F');
+    BOOST_TEST(account_log.m_amount == days);
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "\n\rAdding 20 days to the flatrate.\n\r\n\r");
+}
+
+/**
+ * Days = 20
+ * Flatrate = now() - 10000
+ */
+BOOST_AUTO_TEST_CASE(days_gt_zero_flatrate_lt_now_plus_add)
+{
+    sbit32 days = 20;
+    time_t now = time(nullptr);
+    whom->account.flatrate = now - 10000;
+    const sbit32 expected_flatrate = now + (days * SECS_PER_REAL_DAY);
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_flatrate_change(god.get(), whom.get(), days);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(whom->account.flatrate == expected_flatrate);
+
+    const auto &slog = unit_tests::OutputCapture::Instance()->getSLogData();
+    BOOST_TEST(slog.m_level == LOG_ALL);
+    BOOST_TEST(slog.m_wiz_inv_level == 255);
+    BOOST_TEST(slog.m_fmt == "%s change flatrate with %d on account %s.");
+    BOOST_TEST(slog.m_message == "Thor change flatrate with 20 on account Bilbo.");
+
+    const auto &account_log = unit_tests::OutputCapture::Instance()->getAccountLogData();
+    BOOST_TEST(account_log.m_action == 'F');
+    BOOST_TEST(account_log.m_amount == days);
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "\n\rSetting flatrate to 20 days.\n\r\n\r");
+}
+
+/**
+ * Days = 0
+ * Flatrate = now() + 10000
+ */
+BOOST_AUTO_TEST_CASE(days_eq_zero_flatrate_gt_now)
+{
+    sbit32 days = 0;
+    time_t now = time(nullptr);
+    whom->account.flatrate = now + 10000;
+    const sbit32 expected_flatrate = whom->account.flatrate + (days * SECS_PER_REAL_DAY);
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_flatrate_change(god.get(), whom.get(), days);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(whom->account.flatrate == expected_flatrate);
+
+    const auto &slog = unit_tests::OutputCapture::Instance()->getSLogData();
+    BOOST_TEST(slog.m_level == LOG_ALL);
+    BOOST_TEST(slog.m_wiz_inv_level == 255);
+    BOOST_TEST(slog.m_fmt == "%s change flatrate with %d on account %s.");
+    BOOST_TEST(slog.m_message == "Thor change flatrate with 0 on account Bilbo.");
+
+    const auto &account_log = unit_tests::OutputCapture::Instance()->getAccountLogData();
+    BOOST_TEST(account_log.m_action == 'F');
+    BOOST_TEST(account_log.m_amount == days);
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "\n\rSubtracting 0 days from the flatrate.\n\r\n\r");
+}
+
+/**
+ * Days = 0
+ * Flatrate = now() - 10000
+ */
+BOOST_AUTO_TEST_CASE(days_eq_zero_flatrate_lt_now)
+{
+    sbit32 days = 0;
+    time_t now = time(nullptr);
+    whom->account.flatrate = now - 10000;
+    const sbit32 expected_flatrate = 0;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_flatrate_change(god.get(), whom.get(), days);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(whom->account.flatrate == expected_flatrate);
+
+    const auto &slog = unit_tests::OutputCapture::Instance()->getSLogData();
+    BOOST_TEST(slog.m_level == LOG_ALL);
+    BOOST_TEST(slog.m_wiz_inv_level == 255);
+    BOOST_TEST(slog.m_fmt == "%s change flatrate with %d on account %s.");
+    BOOST_TEST(slog.m_message == "Thor change flatrate with 0 on account Bilbo.");
+
+    const auto &account_log = unit_tests::OutputCapture::Instance()->getAccountLogData();
+    BOOST_TEST(account_log.m_action == 'F');
+    BOOST_TEST(account_log.m_amount == days);
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "\n\rDisabling flatrate, enabling measure rate.\n\r\n\r");
+}
+
+/**
+ * Days = -7
+ * Flatrate = now() + 10000;
+ */
+BOOST_AUTO_TEST_CASE(days_lt_zero_flatrate_gt_now)
+{
+    sbit32 days = -7;
+    time_t now = time(nullptr);
+    whom->account.flatrate = now + 10000;
+    const sbit32 expected_flatrate = 0;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_flatrate_change(god.get(), whom.get(), days);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(whom->account.flatrate == expected_flatrate);
+    const auto &slog = unit_tests::OutputCapture::Instance()->getSLogData();
+    BOOST_TEST(slog.m_level == LOG_ALL);
+    BOOST_TEST(slog.m_wiz_inv_level == 255);
+    BOOST_TEST(slog.m_fmt == "%s change flatrate with %d on account %s.");
+    BOOST_TEST(slog.m_message == "Thor change flatrate with -7 on account Bilbo.");
+
+    const auto &account_log = unit_tests::OutputCapture::Instance()->getAccountLogData();
+    BOOST_TEST(account_log.m_action == 'F');
+    BOOST_TEST(account_log.m_amount == days);
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "\n\rDisabling flatrate, enabling measure rate.\n\r\n\r");
+}
+
+/**
+ * Days = -7
+ * Flatrate = now() + ((days * -1) + 1) * SECS_PER_REAL_DAY
+ */
+BOOST_AUTO_TEST_CASE(days_lt_zero_flatrate_lt_now)
+{
+    sbit32 days = -7;
+    time_t now = time(nullptr);
+    whom->account.flatrate = now + ((days * -1) + 1) * SECS_PER_REAL_DAY;
+    const sbit32 expected_flatrate = whom->account.flatrate + (days * SECS_PER_REAL_DAY);
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_flatrate_change(god.get(), whom.get(), days);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(whom->account.flatrate == expected_flatrate);
+
+    const auto &slog = unit_tests::OutputCapture::Instance()->getSLogData();
+    BOOST_TEST(slog.m_level == LOG_ALL);
+    BOOST_TEST(slog.m_wiz_inv_level == 255);
+    BOOST_TEST(slog.m_fmt == "%s change flatrate with %d on account %s.");
+    BOOST_TEST(slog.m_message == "Thor change flatrate with -7 on account Bilbo.");
+
+    const auto &account_log = unit_tests::OutputCapture::Instance()->getAccountLogData();
+    BOOST_TEST(account_log.m_action == 'F');
+    BOOST_TEST(account_log.m_amount == days);
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "\n\rSubtracting -7 days from the flatrate.\n\r\n\r");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Account_Flatrate_Change_Suite
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Cclog_Suite, AccountCPPFixture)
+
+/**
+ * Happy path call
+ */
+BOOST_AUTO_TEST_CASE(account_cclog_test)
+{
+    const std::string coin_name{"dollar"};
+    std::string logfile = g_cServerConfig.getFileInLogDir(CREDITFILE_LOG);
+    unlink(logfile.c_str());
+
+    int amount = 123456789;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_cclog(whom.get(), amount);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    char buf[1024]{};
+    snprintf(buf, sizeof(buf), "%-16s %6.2f %s\n", UNIT_NAME(whom), ((float)amount) / 100.0, g_cAccountConfig.m_pCoinName);
+
+    std::ifstream in(logfile.c_str(), std::ios::binary);
+    BOOST_TEST(in.good());
+    std::string file((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+
+    BOOST_TEST(file == std::string(buf));
+    unlink(logfile.c_str());
+}
+
+/**
+ * Use name longer than 16 chars
+ */
+BOOST_AUTO_TEST_CASE(account_cclog_long_name_test)
+{
+    const std::string coin_name{"dollar"};
+    std::string logfile = g_cServerConfig.getFileInLogDir(CREDITFILE_LOG);
+    unlink(logfile.c_str());
+
+    int amount = 123456789;
+    whom->names.InsertName("ThisIsAReallyLongNameMoreThanItShouldBe", 0);
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_cclog(whom.get(), amount);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    char buf[1024]{};
+    snprintf(buf, sizeof(buf), "%-16s %6.2f %s\n", UNIT_NAME(whom), ((float)amount) / 100.0, g_cAccountConfig.m_pCoinName);
+
+    std::ifstream in(logfile.c_str(), std::ios::binary);
+    BOOST_TEST(in.good());
+    std::string file((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+
+    BOOST_TEST(file == std::string(buf));
+    unlink(logfile.c_str());
+}
+
+/**
+ * Large amount value
+ */
+BOOST_AUTO_TEST_CASE(account_cclog_long_amount_test)
+{
+    const std::string coin_name{"dollar"};
+    std::string logfile = g_cServerConfig.getFileInLogDir(CREDITFILE_LOG);
+    unlink(logfile.c_str());
+
+    int amount = INT_MAX;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_cclog(whom.get(), amount);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    char buf[1024]{};
+    snprintf(buf, sizeof(buf), "%-16s %6.2f %s\n", UNIT_NAME(whom), ((float)amount) / 100.0, g_cAccountConfig.m_pCoinName);
+
+    std::ifstream in(logfile.c_str(), std::ios::binary);
+    BOOST_TEST(in.good());
+    std::string file((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+
+    BOOST_TEST(file == std::string(buf));
+    unlink(logfile.c_str());
+}
+
+/**
+ * Name > 16 chars and large amount value
+ */
+BOOST_AUTO_TEST_CASE(account_cclog_long_name_and_amount_test)
+{
+    const std::string coin_name{"dollar"};
+    std::string logfile = g_cServerConfig.getFileInLogDir(CREDITFILE_LOG);
+    unlink(logfile.c_str());
+
+    int amount = INT_MAX;
+    whom->names.InsertName("ThisIsAReallyLongNameMoreThanItShouldBe", 0);
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_cclog(whom.get(), amount);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    char buf[1024]{};
+    snprintf(buf, sizeof(buf), "%-16s %6.2f %s\n", UNIT_NAME(whom), ((float)amount) / 100.0, g_cAccountConfig.m_pCoinName);
+
+    std::ifstream in(logfile.c_str(), std::ios::binary);
+    BOOST_TEST(in.good());
+    std::string file((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+
+    BOOST_TEST(file == std::string(buf));
+    unlink(logfile.c_str());
+}
+
+/**
+ * Large negative amount
+ */
+BOOST_AUTO_TEST_CASE(account_cclog_neg_amount_test)
+{
+    const std::string coin_name{"dollar"};
+    std::string logfile = g_cServerConfig.getFileInLogDir(CREDITFILE_LOG);
+    unlink(logfile.c_str());
+
+    int amount = INT_MIN;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_cclog(whom.get(), amount);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    char buf[1024]{};
+    snprintf(buf, sizeof(buf), "%-16s %6.2f %s\n", UNIT_NAME(whom), ((float)amount) / 100.0, g_cAccountConfig.m_pCoinName);
+
+    std::ifstream in(logfile.c_str(), std::ios::binary);
+    BOOST_TEST(in.good());
+    std::string file((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+
+    BOOST_TEST(file == std::string(buf));
+    unlink(logfile.c_str());
+}
+
+BOOST_AUTO_TEST_CASE(account_cclog_no_name_test)
+{
+    const std::string coin_name{"dollar"};
+    std::string logfile = g_cServerConfig.getFileInLogDir(CREDITFILE_LOG);
+    unlink(logfile.c_str());
+
+    int amount = INT_MIN;
+    whom->names.Free();
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_cclog(whom.get(), amount);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    char buf[1024]{};
+    snprintf(buf, sizeof(buf), "%-16s %6.2f %s\n", UNIT_NAME(whom), ((float)amount) / 100.0, g_cAccountConfig.m_pCoinName);
+
+    std::ifstream in(logfile.c_str(), std::ios::binary);
+    BOOST_TEST(in.good());
+    std::string file((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+
+    BOOST_TEST(file == std::string(buf));
+    unlink(logfile.c_str());
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Account_Cclog_Suite
+
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Insert_Suite, AccountCPPFixture)
+BOOST_AUTO_TEST_CASE(account_insert_test)
+{
+    float credit = 3.14f;
+    ubit32 total_credit = 4876;
+
+    int amount = 5546;
+
+    whom->account.credit = credit;
+    whom->account.total_credit = total_credit;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_insert(god.get(), whom.get(), amount);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(whom->account.credit == credit + amount);
+    BOOST_TEST(whom->account.total_credit == total_credit + amount);
+
+    const auto &slog = unit_tests::OutputCapture::Instance()->getSLogData();
+    BOOST_TEST(slog.m_level == LOG_ALL);
+    BOOST_TEST(slog.m_wiz_inv_level == 255);
+    BOOST_TEST(slog.m_fmt == "%s inserted %d on account %s.");
+    BOOST_TEST(slog.m_message == "Thor inserted 5546 on account Bilbo.");
+
+    const auto &account_log = unit_tests::OutputCapture::Instance()->getAccountLogData();
+    BOOST_TEST(account_log.m_action == 'I');
+    BOOST_TEST(account_log.m_amount == amount);
+}
+BOOST_AUTO_TEST_SUITE_END()
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Withdraw_Suite, AccountCPPFixture)
+
+std::vector<int> withdrawal_amounts{274, 2744, 27447};
+BOOST_DATA_TEST_CASE(account_withdraw_test, withdrawal_amounts, amount)
+{
+    float credit = 375.14f;
+    ubit32 total_credit = 4876;
+
+    whom->account.credit = credit;
+    whom->account.total_credit = total_credit;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_withdraw(god.get(), whom.get(), amount);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(whom->account.credit == credit - amount);
+    ubit32 expected_total_credit = total_credit - amount;
+    if (amount > total_credit)
+    {
+        expected_total_credit = 0;
+    }
+    BOOST_TEST(whom->account.total_credit == expected_total_credit);
+
+    auto expected = diku::format_to_str("%s withdrew %d from account %s.", god->names.Name(), amount, whom->names.Name());
+
+    const auto &slog = unit_tests::OutputCapture::Instance()->getSLogData();
+    BOOST_TEST(slog.m_level == LOG_ALL);
+    BOOST_TEST(slog.m_wiz_inv_level == 255);
+    BOOST_TEST(slog.m_fmt == "%s withdrew %d from account %s.");
+    BOOST_TEST(slog.m_message == expected);
+
+    const auto &account_log = unit_tests::OutputCapture::Instance()->getAccountLogData();
+    BOOST_TEST(account_log.m_action == 'W');
+    BOOST_TEST(account_log.m_amount == amount);
+}
+BOOST_AUTO_TEST_SUITE_END() // Account_Withdraw_Suite
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Global_Stat_Suite, AccountCPPFixture)
+
+BOOST_AUTO_TEST_CASE(account_global_stat_disabled_test)
+{
+    g_cServerConfig.disableAccounting();
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_global_stat(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharDataMulti();
+    BOOST_TEST(send_to_char.empty());
+
+    const auto &page_string = unit_tests::OutputCapture::Instance()->getPageStringDataMulti();
+    BOOST_TEST(page_string.empty());
+}
+
+BOOST_AUTO_TEST_CASE(account_global_stat_test)
+{
+    ////////////////////////// Test Subject //////////////////////////////
+    account_global_stat(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    std::string expected("\n\rAccounting mode:\n\r"
+                         "  Free from level : 200\n\r"
+                         "  Currency Name   : dollar\n\r"
+                         "  Default limit   : 0.00\n\r"
+                         "  Default start   : 0.00\n\r\n\r");
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == expected);
+
+    std::string expected_ps("    Time    Sun  Mon  Tir  Wed  Thu  Fri  Sat\n\r"
+                            "   0-  14    0    0    0    0    0    0    0\n\r"
+                            "  15-  29    0    0    0    0    0    0    0\n\r"
+                            "  30-  44    0    0    0    0    0    0    0\n\r"
+                            "  45-  59    0    0    0    0    0    0    0\n\r"
+                            " 100- 114    0    0    0    0    0    0    0\n\r"
+                            " 115- 129    0    0    0    0    0    0    0\n\r"
+                            " 130- 144    0    0    0    0    0    0    0\n\r"
+                            " 145- 159    0    0    0    0    0    0    0\n\r"
+                            " 200- 214    0    0    0    0    0    0    0\n\r"
+                            " 215- 229    0    0    0    0    0    0    0\n\r"
+                            " 230- 244    0    0    0    0    0    0    0\n\r"
+                            " 245- 259    0    0    0    0    0    0    0\n\r"
+                            " 300- 314    0    0    0    0    0    0    0\n\r"
+                            " 315- 329    0    0    0    0    0    0    0\n\r"
+                            " 330- 344    0    0    0    0    0    0    0\n\r"
+                            " 345- 359    0    0    0    0    0    0    0\n\r"
+                            " 400- 414    0    0    0    0    0    0    0\n\r"
+                            " 415- 429    0    0    0    0    0    0    0\n\r"
+                            " 430- 444    0    0    0    0    0    0    0\n\r"
+                            " 445- 459    0    0    0    0    0    0    0\n\r"
+                            " 500- 514    0    0    0    0    0    0    0\n\r"
+                            " 515- 529    0    0    0    0    0    0    0\n\r"
+                            " 530- 544    0    0    0    0    0    0    0\n\r"
+                            " 545- 559    0    0    0    0    0    0    0\n\r"
+                            " 600- 614    0    0    0    0    0    0    0\n\r"
+                            " 615- 629    0    0    0    0    0    0    0\n\r"
+                            " 630- 644    0    0    0    0    0    0    0\n\r"
+                            " 645- 659    0    0    0    0    0    0    0\n\r"
+                            " 700- 714    0    0    0    0    0    0    0\n\r"
+                            " 715- 729    0    0    0    0    0    0    0\n\r"
+                            " 730- 744    0    0    0    0    0    0    0\n\r"
+                            " 745- 759    0    0    0    0    0    0    0\n\r"
+                            " 800- 814    0    0    0    0    0    0    0\n\r"
+                            " 815- 829    0    0    0    0    0    0    0\n\r"
+                            " 830- 844    0    0    0    0    0    0    0\n\r"
+                            " 845- 859    0    0    0    0    0    0    0\n\r"
+                            " 900- 914    0    0    0    0    0    0    0\n\r"
+                            " 915- 929    0    0    0    0    0    0    0\n\r"
+                            " 930- 944    0    0    0    0    0    0    0\n\r"
+                            " 945- 959    0    0    0    0    0    0    0\n\r"
+                            "1000-1014    0    0    0    0    0    0    0\n\r"
+                            "1015-1029    0    0    0    0    0    0    0\n\r"
+                            "1030-1044    0    0    0    0    0    0    0\n\r"
+                            "1045-1059    0    0    0    0    0    0    0\n\r"
+                            "1100-1114    0    0    0    0    0    0    0\n\r"
+                            "1115-1129    0    0    0    0    0    0    0\n\r"
+                            "1130-1144    0    0    0    0    0    0    0\n\r"
+                            "1145-1159    0    0    0    0    0    0    0\n\r"
+                            "1200-1214    0    0    0    0    0    0    0\n\r"
+                            "1215-1229    0    0    0    0    0    0    0\n\r"
+                            "1230-1244    0    0    0    0    0    0    0\n\r"
+                            "1245-1259    0    0    0    0    0    0    0\n\r"
+                            "1300-1314    0    0    0    0    0    0    0\n\r"
+                            "1315-1329    0    0    0    0    0    0    0\n\r"
+                            "1330-1344    0    0    0    0    0    0    0\n\r"
+                            "1345-1359    0    0    0    0    0    0    0\n\r"
+                            "1400-1414    0    0    0    0    0    0    0\n\r"
+                            "1415-1429    0    0    0    0    0    0    0\n\r"
+                            "1430-1444    0    0    0    0    0    0    0\n\r"
+                            "1445-1459    0    0    0    0    0    0    0\n\r"
+                            "1500-1514    0    0    0    0    0    0    0\n\r"
+                            "1515-1529    0    0    0    0    0    0    0\n\r"
+                            "1530-1544    0    0    0    0    0    0    0\n\r"
+                            "1545-1559    0    0    0    0    0    0    0\n\r"
+                            "1600-1614    0    0    0    0    0    0    0\n\r"
+                            "1615-1629    0    0    0    0    0    0    0\n\r"
+                            "1630-1644    0    0    0    0    0    0    0\n\r"
+                            "1645-1659    0    0    0    0    0    0    0\n\r"
+                            "1700-1714    0    0    0    0    0    0    0\n\r"
+                            "1715-1729    0    0    0    0    0    0    0\n\r"
+                            "1730-1744    0    0    0    0    0    0    0\n\r"
+                            "1745-1759    0    0    0    0    0    0    0\n\r"
+                            "1800-1814    0    0    0    0    0    0    0\n\r"
+                            "1815-1829    0    0    0    0    0    0    0\n\r"
+                            "1830-1844    0    0    0    0    0    0    0\n\r"
+                            "1845-1859    0    0    0    0    0    0    0\n\r"
+                            "1900-1914    0    0    0    0    0    0    0\n\r"
+                            "1915-1929    0    0    0    0    0    0    0\n\r"
+                            "1930-1944    0    0    0    0    0    0    0\n\r"
+                            "1945-1959    0    0    0    0    0    0    0\n\r"
+                            "2000-2014    0    0    0    0    0    0    0\n\r"
+                            "2015-2029    0    0    0    0    0    0    0\n\r"
+                            "2030-2044    0    0    0    0    0    0    0\n\r"
+                            "2045-2059    0    0    0    0    0    0    0\n\r"
+                            "2100-2114    0    0    0    0    0    0    0\n\r"
+                            "2115-2129    0    0    0    0    0    0    0\n\r"
+                            "2130-2144    0    0    0    0    0    0    0\n\r"
+                            "2145-2159    0    0    0    0    0    0    0\n\r"
+                            "2200-2214    0    0    0    0    0    0    0\n\r"
+                            "2215-2229    0    0    0    0    0    0    0\n\r"
+                            "2230-2244    0    0    0    0    0    0    0\n\r"
+                            "2245-2259    0    0    0    0    0    0    0\n\r"
+                            "2300-2314    0    0    0    0    0    0    0\n\r"
+                            "2315-2329    0    0    0    0    0    0    0\n\r"
+                            "2330-2344    0    0    0    0    0    0    0\n\r"
+                            "2345-2359    0    0    0    0    0    0    0\n\r");
+    const auto &page_string = unit_tests::OutputCapture::Instance()->getPageStringData();
+    BOOST_TEST(page_string.m_message == expected_ps);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Account_Global_Stat_Suite
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Local_Stat_Suite, AccountCPPFixture)
+BOOST_AUTO_TEST_CASE(account_local_stat_disabled_test)
+{
+    g_cServerConfig.disableAccounting();
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_local_stat(god.get(), whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "Game is not in accounting mode.\n\r");
+}
+
+BOOST_AUTO_TEST_CASE(account_local_stat_npc_test)
+{
+    ////////////////////////// Test Subject //////////////////////////////
+    account_local_stat(god.get(), npc.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "Only players have accounts.\n\r");
+}
+
+BOOST_AUTO_TEST_CASE(account_local_stat_broke_test)
+{
+    ////////////////////////// Test Subject //////////////////////////////
+    account_local_stat(god.get(), whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "Has NOT yet paid for playing.\n\r");
+}
+
+BOOST_AUTO_TEST_CASE(account_local_stat_funds_test)
+{
+    whom->account.total_credit = 5000;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_local_stat(god.get(), whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "Has paid for playing.\n\r");
+}
+
+BOOST_AUTO_TEST_CASE(account_local_stat_admin_test)
+{
+    god->points.level = ADMINISTRATOR_LEVEL;
+    whom->account.total_credit = 5000;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_local_stat(god.get(), whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    std::string expected("Credit         :  0.00\n\r"
+                         "Credit Limit   :  0.00\n\r"
+                         "Credit to date : 50.00\n\r"
+                         "Credit Card    : REGISTERED\n\r"
+                         "Discount       :   0%\n\r"
+                         "Flat Rate      : Expired (none)\n\r"
+                         "Crack counter  :   0\n\r");
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == expected);
+}
+BOOST_AUTO_TEST_SUITE_END() // Account_Local_Stat_Suite
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Defaults_Suite, AccountCPPFixture)
+BOOST_AUTO_TEST_CASE(account_defaults_test)
+{
+    whom->account.credit = 333.0;
+    whom->account.credit_limit = 333;
+    whom->account.total_credit = 333;
+    whom->account.last4 = 333;
+    whom->account.discount = 222;
+    whom->account.cracks = 222;
+    whom->account.flatrate = 333;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    account_defaults(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(whom->account.credit == 0.0);
+    BOOST_TEST(whom->account.credit_limit == 0);
+    BOOST_TEST(whom->account.total_credit == 0);
+    BOOST_TEST(whom->account.last4 == -1);
+    BOOST_TEST(whom->account.discount == 0);
+    BOOST_TEST(whom->account.cracks == 0);
+    BOOST_TEST(whom->account.flatrate == 0);
+}
+BOOST_AUTO_TEST_SUITE_END() // Account_Defaults_Suite
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Subtract_Suite, AccountCPPFixture)
+BOOST_AUTO_TEST_CASE(account_subtract_npc_test)
+{
+    // Don't know how to test this
+    ////////////////////////// Test Subject //////////////////////////////
+    // account_subtract(npc.get(), {}, {});
+    ////////////////////////// Test Subject //////////////////////////////
+}
+BOOST_AUTO_TEST_SUITE_END() // Account_Subtract_Suite
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Is_Overdue_Suite, AccountCPPFixture)
+
+BOOST_AUTO_TEST_CASE(account_is_overdue_test_false_false)
+{
+    g_cServerConfig.disableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 1;
+    whom->points.level = 10;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_overdue(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(rc == FALSE);
+}
+
+BOOST_AUTO_TEST_CASE(account_is_overdue_test_false_true)
+{
+    g_cServerConfig.disableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 10;
+    whom->points.level = 1;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_overdue(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(rc == FALSE);
+}
+
+BOOST_AUTO_TEST_CASE(account_is_overdue_test_true_false)
+{
+    g_cServerConfig.enableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 1;
+    whom->points.level = 10;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_overdue(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(rc == FALSE);
+}
+
+BOOST_AUTO_TEST_CASE(account_is_overdue_test_1)
+{
+    g_cServerConfig.enableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 10;
+    whom->points.level = 1;
+    whom->account.flatrate = time(nullptr) + 10000;
+    whom->account.credit = -1000.00;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_overdue(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(rc == FALSE);
+}
+
+BOOST_AUTO_TEST_CASE(account_is_overdue_test_2)
+{
+    g_cServerConfig.enableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 10;
+    whom->points.level = 1;
+    whom->account.flatrate = time(nullptr) - 10000;
+    whom->account.credit = -1000.00;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_overdue(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(rc == TRUE);
+}
+
+BOOST_AUTO_TEST_CASE(account_is_overdue_test_3)
+{
+    g_cServerConfig.enableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 10;
+    whom->points.level = 1;
+    whom->account.flatrate = time(nullptr) + 10000;
+    whom->account.credit = 1000.00;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_overdue(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(rc == FALSE);
+}
+
+BOOST_AUTO_TEST_CASE(account_is_overdue_test_4)
+{
+    g_cServerConfig.enableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 10;
+    whom->points.level = 1;
+    whom->account.flatrate = time(nullptr) - 10000;
+    whom->account.credit = -1000.00;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_overdue(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(rc == TRUE);
+}
+BOOST_AUTO_TEST_SUITE_END() // Account_Is_Overdue_Suite
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Overdue_Suite, AccountCPPFixture)
+
+BOOST_AUTO_TEST_CASE(account_overdue_test)
+{
+    g_cAccountConfig.m_nHourlyRate = 5;
+    whom->account.credit_limit = 4895;
+    whom->account.credit = 456;
+    ////////////////////////// Test Subject //////////////////////////////
+    account_overdue(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    const auto &msgs = unit_tests::OutputCapture::Instance()->getSendToCharDataMulti();
+
+    BOOST_TEST(msgs.size() == 2);
+    BOOST_TEST(msgs[0].m_message == "Your account is overdue by -4.56 dollar with a limit of 48.95 dollar.\n\r"
+                                    "The account will expire in 1070 hours and 12 minutes.\n\r\n\r");
+    BOOST_TEST(msgs[1].m_message == "&c+yYour account is overdue.&nPlease report this message #1 to Papi.&cw&n");
+}
+
+BOOST_AUTO_TEST_CASE(account_overdue_test_2)
+{
+    whom->account.credit_limit = 4895;
+    whom->account.credit = 456;
+    whom->account.discount = 100;
+    ////////////////////////// Test Subject //////////////////////////////
+    account_overdue(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    const auto &msgs = unit_tests::OutputCapture::Instance()->getSendToCharDataMulti();
+
+    BOOST_TEST(msgs.size() == 2);
+    BOOST_TEST(msgs[0].m_message == "Your account is overdue by -4.56 dollar with a limit of 48.95 dollar.\n\r"
+                                    "The account will expire in 0 hours and 0 minutes.\n\r\n\r");
+    BOOST_TEST(msgs[1].m_message == "&c+yYour account is overdue.&nPlease report this message #1 to Papi.&cw&n");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Account_Overdue_Suite
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Paypoint_Suite, AccountCPPFixture)
+BOOST_AUTO_TEST_CASE(account_paypoint_test)
+{
+    ////////////////////////// Test Subject //////////////////////////////
+    account_paypoint(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "&c+gYou can not enter that part of the game unless you give a donation.&cw&n");
+}
+BOOST_AUTO_TEST_SUITE_END() // Account_Paypoint_Suite
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Closed_Suite, AccountCPPFixture)
+
+BOOST_AUTO_TEST_CASE(account_closed_test_disabled)
+{
+    g_cServerConfig.disableAccounting();
+    ////////////////////////// Test Subject //////////////////////////////
+    account_closed(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharDataMulti();
+    BOOST_TEST(send_to_char.empty());
+}
+
+BOOST_AUTO_TEST_CASE(account_closed_test_enabled)
+{
+    g_cServerConfig.enableAccounting();
+    ////////////////////////// Test Subject //////////////////////////////
+    account_closed(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+    const auto &send_to_char = unit_tests::OutputCapture::Instance()->getSendToCharData();
+    BOOST_TEST(send_to_char.m_message == "&c+rYour account is closed.&nPlease report this message #2 to Papi.&cw&n");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Account_Closed_Suite
+//===========================================================================================
+
+BOOST_FIXTURE_TEST_SUITE(Account_Is_Closed_Suite, AccountCPPFixture)
+BOOST_AUTO_TEST_CASE(account_is_closed_test_1)
+{
+    g_cServerConfig.disableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 10;
+    whom->points.level = 1;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_closed(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(rc == FALSE);
+}
+BOOST_AUTO_TEST_CASE(account_is_closed_test_2)
+{
+    g_cServerConfig.disableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 1;
+    whom->points.level = 10;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_closed(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(rc == FALSE);
+}
+
+BOOST_AUTO_TEST_CASE(account_is_closed_test_3)
+{
+    g_cServerConfig.enableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 1;
+    whom->points.level = 10;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_closed(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(rc == FALSE);
+}
+
+BOOST_AUTO_TEST_CASE(account_is_closed_test_4)
+{
+    g_cServerConfig.enableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 10;
+    whom->points.level = 1;
+    whom->account.flatrate = time(nullptr) + 1000;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_closed(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(rc == FALSE);
+}
+
+BOOST_AUTO_TEST_CASE(account_is_closed_test_5)
+{
+    g_cServerConfig.enableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 10;
+    whom->points.level = 1;
+    whom->account.flatrate = time(nullptr) - 1000;
+    whom->account.credit = -50;
+    whom->account.credit_limit = 100;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_closed(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(rc == FALSE);
+}
+
+BOOST_AUTO_TEST_CASE(account_is_closed_test_6)
+{
+    g_cServerConfig.enableAccounting();
+    g_cAccountConfig.m_nFreeFromLevel = 10;
+    whom->points.level = 1;
+    whom->account.flatrate = time(nullptr) - 1000;
+    whom->account.credit = -500;
+    whom->account.credit_limit = 100;
+    ////////////////////////// Test Subject //////////////////////////////
+    auto rc = account_is_closed(whom.get());
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(rc == TRUE);
+}
+BOOST_AUTO_TEST_SUITE_END() // Account_Is_Closed_Suite
+//===========================================================================================
+
+BOOST_AUTO_TEST_SUITE_END() // Account_Public_Funcs_Suite
+
+// BOOST_AUTO_TEST_SUITE(CAccountConfig_Suite)
+// BOOST_AUTO_TEST_SUITE_END()
+
+#pragma clang diagnostic pop

--- a/unit_tests/generate_reports.sh
+++ b/unit_tests/generate_reports.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This is a bit hardcoded - from top level if you do
+#
+# mkdir build; cd build; cmake -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_C_FLAGS=--coverage -DCMAKE_BUILD_TYPE=Debug ..
+#
+# Then you can run this script to run unit tests and generate report
+
+pushd ..
+toplevel=$(pwd)
+popd
+
+# VME Unit Tests
+lcov -q --directory $toplevel/build --zerocounters
+pushd ../vme/bin
+vme_unit_tests
+popd
+lcov -q --directory $toplevel/build --base-directory $toplevel --capture --no-external --rc lcov_branch_coverage=1 --output-file vme_unit_tests.info
+genhtml vme_unit_tests.info -q --prefix $toplevel --output-directory vme_report --show-details --legend --demangle-cpp --sort --rc lcov_branch_coverage=1
+
+# PP Unit Tests
+lcov -q --directory $toplevel/build --zerocounters
+pushd ../vme/bin
+pp_unit_tests
+popd
+lcov -q --directory $toplevel/build --base-directory $toplevel --capture --no-external --rc lcov_branch_coverage=1 --output-file pp_unit_tests.info
+genhtml pp_unit_tests.info -q --prefix $toplevel --output-directory pp_report --show-details --legend --demangle-cpp --sort --rc lcov_branch_coverage=1
+
+# DEFCOMP Unit Tests
+lcov -q --directory $toplevel/build --zerocounters
+pushd ../vme/bin
+defcomp_unit_tests
+popd
+lcov -q --directory $toplevel/build --base-directory $toplevel --capture --no-external --rc lcov_branch_coverage=1 --output-file defcomp_unit_tests.info
+genhtml defcomp_unit_tests.info -q --prefix $toplevel --output-directory defcomp_report --show-details --legend --demangle-cpp --sort --rc lcov_branch_coverage=1
+
+# VMC Unit Tests
+lcov -q --directory $toplevel/build --zerocounters
+pushd ../vme/bin
+vmc_unit_tests
+popd
+lcov -q --directory $toplevel/build --base-directory $toplevel --capture --no-external --rc lcov_branch_coverage=1 --output-file vmc_unit_tests.info
+genhtml vmc_unit_tests.info -q --prefix $toplevel --output-directory vmc_report --show-details --legend --demangle-cpp --sort --rc lcov_branch_coverage=1
+
+# MPLEX Unit Tests
+lcov -q --directory $toplevel/build --zerocounters
+pushd ../vme/bin
+mplex_unit_tests
+popd
+lcov -q --directory $toplevel/build --base-directory $toplevel --capture --no-external --rc lcov_branch_coverage=1 --output-file mplex_unit_tests.info
+genhtml mplex_unit_tests.info -q --prefix $toplevel --output-directory mplex_report --show-details --legend --demangle-cpp --sort --rc lcov_branch_coverage=1

--- a/unit_tests/weather_cpp_tests.cpp
+++ b/unit_tests/weather_cpp_tests.cpp
@@ -1,0 +1,253 @@
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "cert-err58-cpp"
+
+#include "constants.h"
+#include "structs.h"
+#include "weather.h"
+
+#include <ctime>
+
+#include <boost/test/data/monomorphic.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+
+// Imported prototypes for testing - as the void version isn't easily testable
+time_info_data mud_date(time_t t);
+
+BOOST_TEST_DONT_PRINT_LOG_VALUE(time_info_data)
+
+/**********************************************************************************
+ * Weather_CPP_Suite
+ */
+BOOST_AUTO_TEST_SUITE(Weather_CPP_Suite)
+/**
+ * Some useful constants for tests
+ */
+time_t now = time(nullptr);
+time_t hour_future = now + (60 * 60);
+time_t day_future = now + (60 * 60 * 24);
+time_t month_future = now + (60 * 60 * 24 * 30);
+time_t year_future = now + (60 * 60 * 24 * 365);
+
+/**********************************************************************************
+ * date_defines_test
+ */
+BOOST_AUTO_TEST_CASE(date_defines_test)
+{
+    BOOST_TEST_MESSAGE("Testing SECS_PER_REAL_* constants");
+    BOOST_TEST(SECS_PER_REAL_MIN == 60);
+    BOOST_TEST(SECS_PER_REAL_HOUR == 3600);
+    BOOST_TEST(SECS_PER_REAL_DAY == 86400);
+    BOOST_TEST(SECS_PER_REAL_YEAR == 31536000);
+
+    BOOST_TEST_MESSAGE("Testing MUD_* constants");
+    BOOST_TEST(MUD_DAY == 24);
+    BOOST_TEST(MUD_WEEK == 7);
+    BOOST_TEST(MUD_MONTH == 14);
+    BOOST_TEST(MUD_YEAR == 9);
+
+    BOOST_TEST_MESSAGE("Testing SECS_PER_MUD_* constants");
+    BOOST_TEST(SECS_PER_MUD_HOUR == 300);
+    BOOST_TEST(SECS_PER_MUD_DAY == 7200);
+    BOOST_TEST(SECS_PER_MUD_MONTH == 100800);
+    BOOST_TEST(SECS_PER_MUD_YEAR == 907200);
+
+    BOOST_TEST(g_beginning_of_time == 650336715);
+}
+
+/**********************************************************************************
+ * weekday_constants_tests
+ */
+auto weekdays_ds = boost::unit_test::data::make({
+    "the Day of the Moon",
+    "the Day of the Bull",
+    "the Day of the Deception",
+    "the Day of Thunder",
+    "the Day of Freedom",
+    "the Day of the Great Gods",
+    "the Day of the Sun",
+});
+BOOST_DATA_TEST_CASE(weekday_constants_tests, boost::unit_test::data::xrange(MUD_WEEK) ^ weekdays_ds, index, name)
+{
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(std::string(g_weekdays[index]) == name);
+    ////////////////////////// Test Subject //////////////////////////////
+}
+
+/**********************************************************************************
+ * months_constants_tests
+ */
+auto months_ds = boost::unit_test::data::make({
+    "Month of Winter",
+    "Month of the Winter Wolf",
+    "Month of the Frost Giant",
+    "Month of Spring",
+    "Month of Futility",
+    "Month of the Sun",
+    "Month of the Heat",
+    "Month of the Long Shadows",
+    "Month of the Ancient Darkness",
+});
+BOOST_DATA_TEST_CASE(months_constants_tests, boost::unit_test::data::xrange(MUD_YEAR) ^ months_ds, index, name)
+{
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(std::string(g_month_name[index]) == name);
+    ////////////////////////// Test Subject //////////////////////////////
+}
+
+/**********************************************************************************
+ * mud_time_passed_test
+ */
+auto to_mudtime_dataset = boost::unit_test::data::make({
+    now,          // TEST _0
+    now,          // TEST _1
+    hour_future,  // TEST _2
+    now,          // TEST _3
+    day_future,   // TEST _4
+    now,          // TEST _5
+    month_future, // TEST _6
+    now,          // TEST _7
+    year_future,  // TEST _8
+});
+auto from_mudtime_dataset = boost::unit_test::data::make({
+    now,          // TEST _0
+    hour_future,  // TEST _1
+    now,          // TEST _2
+    day_future,   // TEST _3
+    now,          // TEST _4
+    month_future, // TEST _5
+    now,          // TEST _6
+    year_future,  // TEST _7
+    now,          // TEST _8
+});
+auto expected_mudtime_dataset = boost::unit_test::data::make<time_info_data>({
+    {0, 0, 0, 0},      // TEST _0
+    {-12, 0, 0, 0},    // TEST _1
+    {12, 0, 0, 0},     // TEST _2
+    {0, -12, 0, 0},    // TEST _3
+    {0, 12, 0, 0},     // TEST _4
+    {0, -10, -7, -2},  // TEST _5
+    {0, 10, 7, 2},     // TEST _6
+    {0, -12, -6, -34}, // TEST _7
+    {0, 12, 6, 34},    // TEST _8
+});
+
+BOOST_DATA_TEST_CASE(mud_time_passed_test, to_mudtime_dataset ^ from_mudtime_dataset ^ expected_mudtime_dataset, to, from, expected_result)
+{
+    ////////////////////////// Test Subject //////////////////////////////
+    auto result = mud_time_passed(to, from);
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(result.hours == expected_result.hours);
+    BOOST_TEST(result.day == expected_result.day);
+    BOOST_TEST(result.month == expected_result.month);
+    BOOST_TEST(result.year == expected_result.year);
+}
+
+/**********************************************************************************
+ * real_time_passed_test
+ */
+auto to_real_time_dataset = boost::unit_test::data::make({
+    now,          // Test _0
+    now,          // Test _1
+    hour_future,  // Test _2
+    now,          // Test _3
+    day_future,   // Test _4
+    now,          // Test _5
+    month_future, // Test _6
+    now,          // Test _7
+    year_future,  // Test _8
+});
+auto from_real_time_dataset = boost::unit_test::data::make({
+    now,          // Test _0
+    hour_future,  // Test _1
+    now,          // Test _2
+    day_future,   // Test _3
+    now,          // Test _4
+    month_future, // Test _5
+    now,          // Test _6
+    year_future,  // Test _7
+    now,          // Test _8
+});
+auto expected_real_time_dataset = boost::unit_test::data::make<time_info_data>({
+    {0, 0, -1, 0},   // Test _0
+    {-1, 0, -1, 0},  // Test _1
+    {1, 0, -1, 0},   // Test _2
+    {0, -1, -1, 0},  // Test _3
+    {0, 1, -1, 0},   // Test _4
+    {0, -30, -1, 0}, // Test _5
+    {0, 30, -1, 0},  // Test _6
+    {0, 0, -1, -1},  // Test _7
+    {0, 0, -1, 1},   // Test _8
+});
+
+BOOST_DATA_TEST_CASE(real_time_passed_test,
+                     to_real_time_dataset ^ from_real_time_dataset ^ expected_real_time_dataset,
+                     to,
+                     from,
+                     expected_result)
+{
+    ////////////////////////// Test Subject //////////////////////////////
+    auto result = real_time_passed(to, from);
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(result.hours == expected_result.hours);
+    BOOST_TEST(result.day == expected_result.day);
+    BOOST_TEST(result.month == expected_result.month);
+    BOOST_TEST(result.year == expected_result.year);
+}
+
+/**********************************************************************************
+ * age_npc_test
+ */
+BOOST_AUTO_TEST_CASE(age_npc_test)
+{
+    auto unit = std::unique_ptr<npc_data>(dynamic_cast<npc_data *>(new_unit_data(UNIT_ST_NPC)));
+
+    ////////////////////////// Test Subject //////////////////////////////
+    auto result = age(unit.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(result.hours == 0);
+    BOOST_TEST(result.day == 0);
+    BOOST_TEST(result.month == 0);
+    BOOST_TEST(result.year == 0);
+}
+
+/**********************************************************************************
+ * age_pc_test
+ */
+BOOST_AUTO_TEST_CASE(age_pc_test)
+{
+    auto age_time = time(nullptr) - 7654321;
+    auto unit = std::unique_ptr<pc_data>(dynamic_cast<pc_data *>(new_unit_data(UNIT_ST_PC)));
+    unit->m_time.birth = age_time;
+
+    ////////////////////////// Test Subject //////////////////////////////
+    auto result = age(unit.get());
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(result.hours == 2);
+    BOOST_TEST(result.day == 13);
+    BOOST_TEST(result.month == 3);
+    BOOST_TEST(result.year == 8);
+}
+
+/**********************************************************************************
+ * mud_date_test
+ */
+BOOST_AUTO_TEST_CASE(mud_date_test)
+{
+    time_t test_date = 1640014705; // Mon Dec 20 08:38:25 2021
+
+    ////////////////////////// Test Subject //////////////////////////////
+    auto result = mud_date(test_date);
+    ////////////////////////// Test Subject //////////////////////////////
+
+    BOOST_TEST(result.hours == 6);
+    BOOST_TEST(result.day == 3);
+    BOOST_TEST(result.month == 8);
+    BOOST_TEST(result.year == 1090);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+#pragma clang diagnostic pop

--- a/vme/src/CMakeLists.txt
+++ b/vme/src/CMakeLists.txt
@@ -89,6 +89,7 @@ set(VME_SRCS
         textutil.cpp textutil.h
         tif_affect.cpp tif_affect.h
         trie.cpp trie.h
+        OutputCapture.cpp OutputCapture.h
         unitfind.cpp unitfind.h
         utility.cpp utility.h
         utils.h

--- a/vme/src/OutputCapture.cpp
+++ b/vme/src/OutputCapture.cpp
@@ -1,0 +1,119 @@
+#include "OutputCapture.h"
+
+namespace unit_tests
+{
+std::unique_ptr<OutputCapture> OutputCapture::m_instance;
+
+OutputCapture *OutputCapture::Instance()
+{
+    return m_instance.get();
+}
+
+void OutputCapture::EnableOutputCapture()
+{
+    m_instance = std::unique_ptr<OutputCapture>(new OutputCapture);
+}
+
+void OutputCapture::slog(log_level level, ubit8 wizinv_level, const std::string &fmt, const std::string &msg)
+{
+    if (m_instance)
+    {
+        m_instance->m_slog.emplace_back(slog_data{level, wizinv_level, fmt, msg});
+    }
+}
+
+const slog_data &OutputCapture::getSLogData() const
+{
+    assert(m_slog.size() == 1);
+    return m_slog[0];
+}
+
+const std::vector<slog_data> &OutputCapture::getSLogDataMulti() const
+{
+    return m_slog;
+}
+
+void OutputCapture::account_log(char action, unit_data *, unit_data *, int amount)
+{
+    if (m_instance)
+    {
+        m_instance->m_account_log.emplace_back(account_log_data{action, amount});
+    }
+}
+
+const account_log_data &OutputCapture::getAccountLogData() const
+{
+    assert(m_account_log.size() == 1);
+    return m_account_log[0];
+}
+
+const std::vector<account_log_data> &OutputCapture::getAccountLogDataMulti() const
+{
+    return m_account_log;
+}
+
+void OutputCapture::send_to_char(const char *messg, const unit_data *)
+{
+    if (m_instance)
+    {
+        assert(messg != nullptr);
+        m_instance->m_send_to_char.emplace_back(send_to_char_data{messg});
+    }
+}
+
+void OutputCapture::send_to_char(const std::string &messg, const unit_data *)
+{
+    if (m_instance)
+    {
+        m_instance->m_send_to_char.emplace_back(send_to_char_data{messg});
+    }
+}
+
+const send_to_char_data &OutputCapture::getSendToCharData() const
+{
+    assert(m_send_to_char.size() == 1);
+    return m_send_to_char[0];
+}
+
+const std::vector<send_to_char_data> &OutputCapture::getSendToCharDataMulti() const
+{
+    return m_send_to_char;
+}
+
+void OutputCapture::page_string(descriptor_data *, const std::string &msg)
+{
+    if (m_instance)
+    {
+        m_instance->m_page_string.emplace_back(page_string_data{msg});
+    }
+}
+
+void OutputCapture::page_string(descriptor_data *, const char *msg)
+{
+    if (m_instance && msg != nullptr)
+    {
+        assert(msg != nullptr);
+        m_instance->m_page_string.emplace_back(page_string_data{msg});
+    }
+}
+
+const page_string_data &OutputCapture::getPageStringData() const
+{
+    assert(m_page_string.size() == 1);
+    return m_page_string[0];
+}
+
+const std::vector<page_string_data> &OutputCapture::getPageStringDataMulti() const
+{
+    return m_page_string;
+}
+
+void OutputCapture::Clear()
+{
+    m_slog.clear();
+    m_account_log.clear();
+    m_send_to_char.clear();
+    m_page_string.clear();
+}
+
+} // namespace unit_tests

--- a/vme/src/OutputCapture.h
+++ b/vme/src/OutputCapture.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "structs.h"
+#include "utility.h"
+
+#include <memory>
+
+namespace unit_tests
+{
+
+struct slog_data
+{
+    int m_level{};
+    int m_wiz_inv_level{};
+    std::string m_fmt{};
+    std::string m_message{};
+};
+
+struct account_log_data
+{
+    char m_action{};
+    int m_amount{};
+};
+
+struct send_to_char_data
+{
+    std::string m_message{};
+};
+
+struct page_string_data
+{
+    std::string m_message{};
+};
+
+class OutputCapture
+{
+public:
+    OutputCapture(OutputCapture &) = delete;
+    OutputCapture(OutputCapture &&) = delete;
+    OutputCapture &operator=(OutputCapture &) = delete;
+    OutputCapture &operator=(OutputCapture &&) = delete;
+    ~OutputCapture() = default;
+
+    static OutputCapture *Instance();
+    static void EnableOutputCapture();
+
+    static void slog(log_level level, ubit8 wizinv_level, const std::string &fmt, const std::string &msg);
+    [[nodiscard]] const slog_data &getSLogData() const;
+    [[nodiscard]] const std::vector<slog_data> &getSLogDataMulti() const;
+
+    static void account_log(char action, unit_data *god, unit_data *pc, int amount);
+    [[nodiscard]] const account_log_data &getAccountLogData() const;
+    [[nodiscard]] const std::vector<account_log_data> &getAccountLogDataMulti() const;
+
+    static void send_to_char(const std::string &messg, const unit_data *ch);
+    static void send_to_char(const char *messg, const unit_data *ch);
+    [[nodiscard]] const send_to_char_data &getSendToCharData() const;
+    [[nodiscard]] const std::vector<send_to_char_data> &getSendToCharDataMulti() const;
+
+    static void page_string(descriptor_data *d, const std::string &);
+    static void page_string(descriptor_data *d, const char *);
+    [[nodiscard]] const page_string_data &getPageStringData() const;
+    [[nodiscard]] const std::vector<page_string_data> &getPageStringDataMulti() const;
+
+    void Clear();
+
+private:
+    OutputCapture() = default;
+
+    static std::unique_ptr<OutputCapture> m_instance; // Only created during unit testing
+    std::vector<slog_data> m_slog;                    // Captured log messages to slog
+    std::vector<account_log_data> m_account_log;      // Captured log messages to account_log
+    std::vector<send_to_char_data> m_send_to_char;    // Captured messages to send_to_char
+    std::vector<page_string_data> m_page_string;      // Captured message to page_string
+};
+
+} // namespace unit_tests

--- a/vme/src/account.cpp
+++ b/vme/src/account.cpp
@@ -53,6 +53,9 @@ void account_cclog(class unit_data *ch, int amount)
 
 static void account_log(char action, class unit_data *god, class unit_data *pc, int amount)
 {
+    // If a unit test is being run, send results there too
+    unit_tests::OutputCapture::account_log(action, god, pc, amount);
+
     time_t now = time(nullptr);
     char *c;
     char buf[1024];

--- a/vme/src/comm.cpp
+++ b/vme/src/comm.cpp
@@ -177,6 +177,9 @@ void send_to_descriptor(const std::string &messg, class descriptor_data *d)
 
 void page_string(class descriptor_data *d, const char *messg)
 {
+    // If a unit test is being run, send results there too
+    unit_tests::OutputCapture::page_string(d, messg);
+
     if (d && messg && *messg)
     {
         std::string mystr;
@@ -202,6 +205,9 @@ void page_string(class descriptor_data *d, const std::string &messg)
 
 void send_to_char(const char *messg, const class unit_data *ch)
 {
+    // If a unit test is being run, send results there too
+    unit_tests::OutputCapture::send_to_char(messg, ch);
+
     if (IS_CHAR(ch))
     {
         send_to_descriptor(messg, CHAR_DESCRIPTOR(ch));

--- a/vme/src/config.cpp
+++ b/vme/src/config.cpp
@@ -292,6 +292,16 @@ bool CServerConfiguration::isAccounting() const
     return m_bAccounting;
 }
 
+void CServerConfiguration::enableAccounting()
+{
+    m_bAccounting = true;
+}
+
+void CServerConfiguration::disableAccounting()
+{
+    m_bAccounting = false;
+}
+
 bool CServerConfiguration::isAliasShout() const
 {
     return m_bAliasShout;

--- a/vme/src/config.h
+++ b/vme/src/config.h
@@ -63,6 +63,8 @@ public:
     [[nodiscard]] const in_addr &getSubnetMask() const;
     [[nodiscard]] const std::string &getZoneDir() const;
 
+    void enableAccounting();
+    void disableAccounting();
     /**
      * Generates a string of the path with the filename appended
      *

--- a/vme/src/mplex2/CMakeLists.txt
+++ b/vme/src/mplex2/CMakeLists.txt
@@ -19,6 +19,7 @@ set(MPLEX_SRCS
         ../slog_raw.cpp ../slog_raw.h
         ../textutil.cpp ../textutil.h
         ../utility.cpp ../utility.h
+        ../OutputCapture.cpp ../OutputCapture.h
         )
 
 

--- a/vme/src/slog.h
+++ b/vme/src/slog.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "OutputCapture.h"
 #include "formatter.h"
 #include "slog_raw.h"
 #include "utility.h"
@@ -31,6 +32,9 @@ void slog(log_level level, ubit8 wizinv_level, const std::string &fmt, ParamPack
     {
         formatted_text = fmt;
     }
+
+    // If a unit test is being run, send results there too
+    unit_tests::OutputCapture::slog(level, wizinv_level, fmt, formatted_text);
 
     std::string buf;
 

--- a/vme/src/vmc/CMakeLists.txt
+++ b/vme/src/vmc/CMakeLists.txt
@@ -23,6 +23,7 @@ set(VMC_SRCS
         ../structs.cpp ../structs.h
         ../textutil.cpp ../textutil.h
         ../utility.cpp ../utility.h
+        ../OutputCapture.cpp ../OutputCapture.h
         )
 
 BISON_TARGET(vmcpar vmcpar.y


### PR DESCRIPTION
Adds framework for testing messages sent to slog, account_log,
page_string, send_to_char

This includes the groundwork for  hooking of output from various send/log functions
which hopefully can aid automating the run of zone unit_tests. 