### PR TITLE
Script clang-tidy initialize pod type variables

### DIFF
--- a/clang-tidy-init-variables.sh
+++ b/clang-tidy-init-variables.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#https://clang.llvm.org/extra/clang-tidy/checks/readability-isolate-declaration.html
+#https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-init-variables.html
 
 tidy_binary=clang-tidy-12
 which ${tidy_binary} > /dev/null 2>&1
@@ -238,7 +238,7 @@ popd
 for source in $sources
 do
    echo "Selecting [$source] for tidying!"
-   ${tidy_binary} -p $tmpdir --quiet --checks="-*,readability-isolate-declaration" --fix $source || exit 1
+   ${tidy_binary} -p $tmpdir --quiet --checks="-*,cppcoreguidelines-init-variables" --fix $source || exit 1
    clang-format -i $source
 done
 rm -rf $tmpdir

--- a/vme/src/db_file.cpp
+++ b/vme/src/db_file.cpp
@@ -1060,12 +1060,14 @@ void bwrite_func(CByteBuffer *pBuf, class unit_fptr *fptr)
                         pBuf->AppendNames((const char **)dilargs->dilarg[j].data.stringlist, 0);
                         break;
                     case DILV_ILP:
+                    {
                         int myi;
                         for (myi = 0; myi <= ((int *)dilargs->dilarg[j].data.intlist)[0]; myi++)
                         {
                             pBuf->Append32(((int *)dilargs->dilarg[j].data.intlist)[myi]);
                         }
-                        break;
+                    }
+                    break;
                     case DILV_SP:
                         pBuf->AppendString(dilargs->dilarg[j].data.string);
                         break;

--- a/vme/src/event.cpp
+++ b/vme/src/event.cpp
@@ -192,7 +192,7 @@ void eventqueue::process(void)
     struct timeval old;
     struct timeval pnow;
     ubit32 us;
-    void (*tfunc)(void *, void *);
+    void (*tfunc)(void *, void *) = nullptr;
     loop_process = 0;
     gettimeofday(&old, (struct timezone *)nullptr);
 


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-init-variables.html

After running this we should be aware of any bugs that relied on uninitialized variables.