### PR TITLE
Script clang-tidy to remove redunant voids

### DIFF
--- a/clang-tidy-redundant-void.sh
+++ b/clang-tidy-redundant-void.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-init-variables.html
+#https://clang.llvm.org/extra/clang-tidy/checks/modernize-redundant-void-arg.html
 
 tidy_binary=clang-tidy-12
 which ${tidy_binary} > /dev/null 2>&1
@@ -238,7 +238,7 @@ popd
 for source in $sources
 do
    echo "Selecting [$source] for tidying!"
-   ${tidy_binary} -p $tmpdir --quiet --checks="-*,cppcoreguidelines-init-variables" --fix $source || exit 1
+   ${tidy_binary} -p $tmpdir --quiet --checks="-*,modernize-redundant-void-arg" --fix $source || exit 1
    clang-format -i $source
 done
 rm -rf $tmpdir


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/modernize-redundant-void-arg.html

New script to run to modernize and remove redundant voids