### PR TITLE
Added namespace to mplex

### DIFF
--- a/vme/src/mplex2/ClientConnector.cpp
+++ b/vme/src/mplex2/ClientConnector.cpp
@@ -61,6 +61,8 @@
     have their m_nId set to zero.
 
 */
+namespace mplex
+{
 
 class cConHook *g_connection_list = nullptr;
 
@@ -1601,3 +1603,5 @@ cConHook::~cConHook()
 
     g_nConnectionsLeft++;
 }
+
+} // namespace mplex

--- a/vme/src/mplex2/ClientConnector.h
+++ b/vme/src/mplex2/ClientConnector.h
@@ -17,6 +17,9 @@
 #include <websocketpp/config/asio_no_tls.hpp>
 #include <websocketpp/server.hpp>
 
+namespace mplex
+{
+
 // typedef websocketpp::server<websocketpp::config::asio> wsserver;
 typedef class websocketpp::server<websocketpp::config::asio> wsserver;
 
@@ -107,3 +110,5 @@ void Idle(cConHook *con, const char *cmd);
 void ClearUnhooked();
 
 extern class cConHook *g_connection_list;
+
+} // namespace mplex

--- a/vme/src/mplex2/MUDConnector.cpp
+++ b/vme/src/mplex2/MUDConnector.cpp
@@ -34,6 +34,9 @@
 #include <cstring>
 #include <thread>
 
+namespace mplex
+{
+
 class color_type g_cDefcolor;
 int g_nConnectionsLeft = -1;
 
@@ -470,3 +473,5 @@ int cMudHook::read_mud()
 
     return 1;
 }
+
+} // namespace mplex

--- a/vme/src/mplex2/MUDConnector.h
+++ b/vme/src/mplex2/MUDConnector.h
@@ -15,6 +15,9 @@
 
 #include <cstring>
 
+namespace mplex
+{
+
 class cMotherHook : public cHook
 {
 public:
@@ -41,3 +44,5 @@ extern cMotherHook g_MotherHook;
 extern cMudHook g_MudHook;
 extern int g_nConnectionsLeft;
 extern class color_type g_cDefcolor;
+
+} // namespace mplex

--- a/vme/src/mplex2/echo_server.cpp
+++ b/vme/src/mplex2/echo_server.cpp
@@ -12,6 +12,9 @@ using websocketpp::lib::bind;
 using websocketpp::lib::placeholders::_1;
 using websocketpp::lib::placeholders::_2;
 
+namespace mplex
+{
+
 // pull out the type of messages sent by our config
 typedef wsserver::message_ptr message_ptr;
 
@@ -171,3 +174,5 @@ void runechoserver()
         exit(42);
     }
 }
+
+} // namespace mplex

--- a/vme/src/mplex2/echo_server.h
+++ b/vme/src/mplex2/echo_server.h
@@ -2,6 +2,11 @@
 
 #include "ClientConnector.h"
 
+namespace mplex
+{
+
 void runechoserver();
 void remove_gmap(class cConHook *con);
 int ws_send_message(wsserver *s, websocketpp::connection_hdl hdl, const char *txt);
+
+} // namespace mplex

--- a/vme/src/mplex2/main.cpp
+++ b/vme/src/mplex2/main.cpp
@@ -44,53 +44,53 @@ int main(int argc, char *argv[])
 
     assert(i++ == 0); /* Make sure we dont call ourselves... cheap hack! :) */
 
-    if (!ParseArg(argc, argv, &g_mplex_arg))
+    if (!ParseArg(argc, argv, &mplex::g_mplex_arg))
     {
         exit(0);
     }
 
 #ifndef _WINDOWS
-    signal(SIGQUIT, bye_signal);
-    signal(SIGHUP, bye_signal);
-    signal(SIGINT, bye_signal);
-    signal(SIGTERM, bye_signal);
-    signal(SIGALRM, alarm_signal);
+    signal(SIGQUIT, mplex::bye_signal);
+    signal(SIGHUP, mplex::bye_signal);
+    signal(SIGINT, mplex::bye_signal);
+    signal(SIGTERM, mplex::bye_signal);
+    signal(SIGALRM, mplex::alarm_signal);
 #endif
     /* MS2020 Websockets test hack */
-    translate_init();
+    mplex::translate_init();
 
     slog(LOG_ALL, 0, "MPlex compiled with [%s]", get_compiled_hash_defines().c_str());
-    slog(LOG_OFF, 0, "Opening mother connection on port %d.", g_mplex_arg.nMotherPort);
+    slog(LOG_OFF, 0, "Opening mother connection on port %d.", mplex::g_mplex_arg.nMotherPort);
 
-    if (g_mplex_arg.bWebSockets)
+    if (mplex::g_mplex_arg.bWebSockets)
     {
         /* MS2020 Websockets test hack */
-        std::thread t1(runechoserver);
+        std::thread t1(mplex::runechoserver);
         t1.detach();
     }
     else
     {
-        fd = OpenMother(g_mplex_arg.nMotherPort);
+        fd = mplex::OpenMother(mplex::g_mplex_arg.nMotherPort);
         Assert(fd != -1, "NO MOTHER CONNECTION.");
 
-        if (g_MotherHook.tfd() != -1)
+        if (mplex::g_MotherHook.tfd() != -1)
         {
             slog(LOG_ALL, 0, "Hook() in main called with a non -1 fd.");
         }
 
-        g_CaptainHook.Hook(fd, &g_MotherHook);
+        g_CaptainHook.Hook(fd, &mplex::g_MotherHook);
     }
 
     /* Subtract stdout, stdin, stderr, fdmud, fdmother and 2 to be safe. */
 #if defined(_WINDOWS)
     g_nActiveConnections = 256 - 3 - 2 - 2;
 #else
-    g_nConnectionsLeft = getdtablesize() - 3 - 2 - 2;
+    mplex::g_nConnectionsLeft = getdtablesize() - 3 - 2 - 2;
 #endif
-    Control();
+    mplex::Control();
 
-    g_MudHook.Unhook();
-    g_MotherHook.Unhook();
+    mplex::g_MudHook.Unhook();
+    mplex::g_MotherHook.Unhook();
 
     return 0;
 }

--- a/vme/src/mplex2/mplex.cpp
+++ b/vme/src/mplex2/mplex.cpp
@@ -30,6 +30,9 @@
 #include <cstdio>
 #include <cstdlib>
 
+namespace mplex
+{
+
 char g_mudname[50] = "the MUD server (via DikuMUD Mplex)";
 int g_bHadAlarm = FALSE;
 struct arg_type g_mplex_arg;
@@ -203,3 +206,5 @@ int ParseArg(int argc, char *argv[], struct arg_type *arg)
 
     return TRUE;
 }
+
+} // namespace mplex

--- a/vme/src/mplex2/mplex.h
+++ b/vme/src/mplex2/mplex.h
@@ -15,6 +15,9 @@
 
 #include <cstring>
 
+namespace mplex
+{
+
 struct arg_type
 {
     int nMotherPort;
@@ -46,3 +49,5 @@ extern char g_mudname[50];
 int ParseArg(int argc, char *argv[], struct arg_type *arg);
 void bye_signal(int signal);
 void alarm_signal(int sig);
+
+} // namespace mplex

--- a/vme/src/mplex2/network.cpp
+++ b/vme/src/mplex2/network.cpp
@@ -23,6 +23,9 @@
 #include <cerrno>
 #include <cstdlib>
 
+namespace mplex
+{
+
 int OpenMother(int nPort)
 {
     int n = 0;
@@ -198,3 +201,5 @@ int OpenNetwork(int nPort, char *pcAddress)
     }
     return fdClient;
 }
+
+} // namespace mplex

--- a/vme/src/mplex2/network.h
+++ b/vme/src/mplex2/network.h
@@ -19,5 +19,11 @@
 #endif
 
 #define DEF_SERVER_ADDR "127.0.0.1"
+
+namespace mplex
+{
+
 int OpenMother(int port);
 int OpenNetwork(int nMudPort, char *pMudAddr);
+
+} // namespace mplex

--- a/vme/src/mplex2/translate.cpp
+++ b/vme/src/mplex2/translate.cpp
@@ -22,6 +22,9 @@
 
 #include <cstdio>
 
+namespace mplex
+{
+
 static ubit8 default_colours[3][24] = {
     /* Default (no change in table) */
     {CONTROL_FG_BLACK_CHAR,  CONTROL_FG_RED_CHAR,      CONTROL_FG_GREEN_CHAR,  CONTROL_FG_YELLOW_CHAR,
@@ -625,3 +628,5 @@ void translate_init()
         control_code[TERM_INTERNAL][i] = Control_Copy;
     }
 }
+
+} // namespace mplex

--- a/vme/src/mplex2/translate.h
+++ b/vme/src/mplex2/translate.h
@@ -8,6 +8,9 @@
 
 #include "essential.h"
 
+namespace mplex
+{
+
 void protocol_translate(class cConHook *con, ubit8 code, char **b);
 void translate_init();
 
@@ -221,3 +224,5 @@ void Control_ANSI_Echo_Off(class cConHook *con, char **b, ubit8 code);
 #define CONTROL_BG_WHITE                                                                                                                   \
     "\x1B"                                                                                                                                 \
     "x"
+
+} // namespace mplex


### PR DESCRIPTION
Mplex shares some class names with VMC so for simplicity move
all of mplex into its own namespace to avoid any confusion