### PR TITLE
Add check to unit test for new zone/dat files

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories (${Boost_INCLUDE_DIRS})
+include_directories(${Boost_INCLUDE_DIRS})
 
 find_package(OpenSSL)
 
@@ -13,8 +13,9 @@ add_executable(vme_unit_tests
         weather_cpp_tests.cpp
         )
 target_link_options(vme_unit_tests PUBLIC -Wl,-zmuldefs)
-target_compile_definitions(vme_unit_tests
-        PUBLIC DMSERVER RAPIDJSON_HAS_STDSTRING
+target_compile_definitions(vme_unit_tests PUBLIC
+        DMSERVER
+        RAPIDJSON_HAS_STDSTRING
         )
 target_link_libraries(vme_unit_tests
         vme_objs
@@ -37,7 +38,9 @@ add_executable(vmc_unit_tests
         )
 target_compile_definitions(vmc_unit_tests PUBLIC
         VMC_SRC
-        VMC MUD_DEBUG RAPIDJSON_HAS_STDSTRING
+        VMC
+        MUD_DEBUG
+        RAPIDJSON_HAS_STDSTRING
         )
 target_link_libraries(vmc_unit_tests
         vmc_objs
@@ -55,8 +58,9 @@ add_test(NAME vmc_unit_tests
 add_executable(pp_unit_tests
         pp_main.cpp
         )
-target_compile_definitions(pp_unit_tests
-        PUBLIC DMSERVER RAPIDJSON_HAS_STDSTRING
+target_compile_definitions(pp_unit_tests PUBLIC
+        DMSERVER
+        RAPIDJSON_HAS_STDSTRING
         )
 target_link_libraries(pp_unit_tests
         pp_objs
@@ -72,8 +76,9 @@ add_test(NAME pp_unit_tests
 add_executable(mplex_unit_tests
         mplex_main.cpp
         )
-target_compile_definitions(mplex_unit_tests
-        PUBLIC DMSERVER RAPIDJSON_HAS_STDSTRING
+target_compile_definitions(mplex_unit_tests PUBLIC
+        DMSERVER
+        RAPIDJSON_HAS_STDSTRING
         )
 target_link_libraries(mplex_unit_tests
         mplex_objs
@@ -91,8 +96,9 @@ add_executable(defcomp_unit_tests
         checksum_dataset.cpp checksum_dataset.h
         sha512.cpp sha512.h
         )
-target_compile_definitions(defcomp_unit_tests
-        PUBLIC DMSERVER RAPIDJSON_HAS_STDSTRING
+target_compile_definitions(defcomp_unit_tests PUBLIC
+        DMSERVER
+        RAPIDJSON_HAS_STDSTRING
         )
 target_link_libraries(defcomp_unit_tests
         defcomp_objs

--- a/unit_tests/checksum_dataset.cpp
+++ b/unit_tests/checksum_dataset.cpp
@@ -15,17 +15,88 @@ checksum_dataset::checksum_dataset(const std::string &json_filename)
 
     for (auto &file_set : doc.GetArray())
     {
+        auto relative_path = file_set["relative_path"].Get<std::string>();
+        auto error_fmt_str = file_set["error_fmt_str"].Get<std::string>();
+
+        auto directory_listing = create_directory_listing(relative_path, file_set["new_file_check"]);
+
         for (auto &file_data : file_set["files"].GetArray())
         {
-            auto full_filename = file_set["relative_path"].Get<std::string>();
-            full_filename += file_data["filename"].Get<std::string>();
+            auto filename = file_data["filename"].Get<std::string>();
+            auto full_filename = relative_path + filename;
 
-            emplace_back(FileInfo{file_set["error_fmt_str"].Get<std::string>(), full_filename, file_data["sha512"].Get<std::string>()});
+            emplace_back(FileInfo{error_fmt_str, full_filename, file_data["sha512"].Get<std::string>()});
+
+            // This file has an entry in the json so remove it from the list
+            directory_listing.erase(filename);
+        }
+
+        for (auto &new_file : directory_listing)
+        {
+            // All that should be left are new files without sha512's in the json config
+            // so add a fake sha512 for them so the tests fail
+            auto full_filename = relative_path + new_file;
+            emplace_back(FileInfo{error_fmt_str, full_filename, "New file! Update sha512 in json"});
         }
     }
+
     std::cout << "Loaded " << size() << " checksums from " << json_filename << " to check\n";
 }
 
+/*
+ * This is what the json looks like rapidjson::Value
+ *
+ * {
+ * "files_to_skip": [],
+ * "file_extensions": [
+ *   ".data",
+ *   ".reset"
+ * ]
+ * },
+ */
+std::set<std::string> checksum_dataset::create_directory_listing(const std::string &relative_path, const rapidjson::Value &value)
+{
+    std::set<std::string> skip;
+    for (auto &filename : value["files_to_skip"].GetArray())
+    {
+        skip.insert(filename.Get<std::string>());
+    }
+
+    std::set<std::string> file_extensions;
+    for (auto &ext : value["file_extensions"].GetArray())
+    {
+        file_extensions.insert(ext.Get<std::string>());
+    }
+
+    std::set<std::string> result;
+    for (const auto &dir_entry : std::filesystem::directory_iterator{relative_path})
+    {
+        // Is it a file
+        if (!dir_entry.is_regular_file())
+        {
+            continue;
+        }
+
+        auto filename = dir_entry.path().filename();
+
+        // Does the file extension match
+        if (file_extensions.find(filename.extension()) == file_extensions.end())
+        {
+            continue;
+        }
+
+        // Should it be skipped
+        if (skip.find(filename) != skip.end())
+        {
+            continue;
+        }
+
+        result.insert(filename);
+    }
+    return result;
+}
+
+////////////////////////// Helper Printer for Boost ///////////////////////////////////
 std::ostream &operator<<(std::ostream &os, const FileInfo &fi)
 {
     os << fi.full_filename;

--- a/unit_tests/checksum_dataset.h
+++ b/unit_tests/checksum_dataset.h
@@ -5,6 +5,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <set>
 #include <vector>
 
 #include <boost/test/data/monomorphic.hpp>
@@ -27,8 +28,9 @@ public:
     };
 
     checksum_dataset(const std::string &json_filename);
-
     ~checksum_dataset() = default;
+
+    std::set<std::string> create_directory_listing(const std::string &relative_path, const rapidjson::Value &value);
 };
 
 namespace boost::unit_test::data::monomorphic

--- a/unit_tests/defcomp_checksum_tests.json
+++ b/unit_tests/defcomp_checksum_tests.json
@@ -2,6 +2,20 @@
   {
     "name": "etc Directory Files",
     "relative_path": "../etc/",
+    "new_file_check": {
+      "files_to_skip": [
+        "abilities.dat",
+        "commands.dat",
+        "professions.dat",
+        "races.dat",
+        "sector.dat",
+        "spells.dat",
+        "weapons.dat"
+      ],
+      "file_extensions": [
+        ".dat"
+      ]
+    },
     "error_fmt_str": "Compiled etc file: %1% has changed.\nexpected  = %2%\ncalculated= %3%\nPlease update corresponding checksum in unit_tests/defcomp_checksum_tests.json with command 'sha512sum %1%'\n",
     "files": [
       {

--- a/unit_tests/vmc_checksum_tests.json
+++ b/unit_tests/vmc_checksum_tests.json
@@ -2,6 +2,14 @@
   {
     "name": "etc Directory Files",
     "relative_path": "../etc/",
+    "new_file_check": {
+      "files_to_skip": [
+        "color.dat"
+      ],
+      "file_extensions": [
+        ".dat"
+      ]
+    },
     "error_fmt_str": "Compiled etc file: %1% has changed.\nexpected  = %2%\ncalculated= %3%\nPlease update corresponding checksum in unit_tests/vmc_checksum_tests.json with command 'sha512sum %1%'\n",
     "files": [
       {
@@ -37,6 +45,13 @@
   {
     "name": "zone Directory Files",
     "relative_path": "../zone/",
+    "new_file_check": {
+      "files_to_skip": [],
+      "file_extensions": [
+        ".data",
+        ".reset"
+      ]
+    },
     "error_fmt_str": "Compiled zone file: %1% has changed.\nexpected  = %2%\ncalculated= %3%\nPlease update corresponding checksum in unit_tests/vmc_checksum_tests.json with command 'sha512sum %1%'\n",
     "files": [
       {


### PR DESCRIPTION
Check to see if there is a new zone/dat file that does not have
a sha512 in the json config and fail the test so the dev can
add it to existing checks.