### PR TITLE
Modified the CREATE/RECREATE check type created

### DIFF
--- a/vme/src/db.cpp
+++ b/vme/src/db.cpp
@@ -1752,7 +1752,7 @@ zone_reset_cmd *read_zone(FILE *f, zone_reset_cmd *cmd_list)
 
     while (((cmdno = (ubit8)fgetc(f)) != 255) && !feof(f))
     {
-        CREATE(cmd, zone_reset_cmd, 1);
+        cmd=new zone_reset_cmd();
         cmd->setCommandNum(cmdno);
 
         fstrcpy(&cBuf, f);

--- a/vme/src/essential.h
+++ b/vme/src/essential.h
@@ -101,11 +101,19 @@ using ubit1 = bool;      /* Boolean */
 
 #define CREATE(res, type, num)                                                                                                             \
     if (((res) = (type *)calloc((num), sizeof(type))) == NULL)                                                                             \
-        assert(FALSE);
+    {                                                                                                                                      \
+        /* Make sure CREATE isn't being used to create the new classes instead of the structs they used to be */                           \
+        static_assert(std::is_pod<type>::value);                                                                                           \
+        assert(FALSE);                                                                                                                     \
+    }
 
 #define RECREATE(res, type, num)                                                                                                           \
     if (((res) = (type *)realloc((res), sizeof(type) * (num))) == NULL)                                                                    \
-        assert(FALSE);
+    {                                                                                                                                      \
+        /* Make sure RECREATE isn't being used to create the new classes instead of the structs they used to be */                         \
+        static_assert(std::is_pod<type>::value);                                                                                           \
+        assert(FALSE);                                                                                                                     \
+    }
 
 #define FREE(p)                                                                                                                            \
     {                                                                                                                                      \


### PR DESCRIPTION
Now ctors/dtors are being added instead of POD (aka Plain Old Data)
structs that used to be, added protection to the macros to cause
compile errors if they are used to create a class/struct with ctors
etc.