### PR TITLE
Remove const/volatile qualifiers from 1 byte vars

### DIFF
--- a/vme/src/formatter.h
+++ b/vme/src/formatter.h
@@ -27,8 +27,8 @@ namespace diku
 template<typename T>
 void format(boost::format &formatter, T &&last_value)
 {
-    if constexpr (std::is_same_v<typename std::remove_reference<T>::type, uint8_t> ||
-                  std::is_same_v<typename std::remove_reference<T>::type, int8_t>)
+    if constexpr (std::is_same_v<typename std::remove_cv<typename std::remove_reference<T>::type>::type, uint8_t> ||
+                  std::is_same_v<typename std::remove_cv<typename std::remove_reference<T>::type>::type, int8_t>)
     {
         // Upcasting (u)int8_t's so that they print numbers not the character
         formatter % static_cast<int16_t>(last_value);
@@ -56,8 +56,8 @@ void format(boost::format &formatter, T &&last_value)
 template<typename T, typename... ParamPack>
 void format(boost::format &formatter, T &&first_arg, ParamPack &&...rest_args)
 {
-    if constexpr (std::is_same_v<typename std::remove_reference<T>::type, uint8_t> ||
-                  std::is_same_v<typename std::remove_reference<T>::type, int8_t>)
+    if constexpr (std::is_same_v<typename std::remove_cv<typename std::remove_reference<T>::type>::type, uint8_t> ||
+                  std::is_same_v<typename std::remove_cv<typename std::remove_reference<T>::type>::type, int8_t>)
     {
         // Upcasting (u)int8_t's so that they print numbers not the character
         formatter % static_cast<int16_t>(first_arg);


### PR DESCRIPTION
When formatting 1 byte variables the compiler treats them
differently if they came from a const function call so then
widening cast in formatter gets skipped as 'const uint8_t'
is not 'uint8_t' and is gets printed as a bytes vs as integer