### PR TITLE
Add cmake options to profile and optimize build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ CTestTestfile.cmake
 Testing/
 unit_tests/CTestTestfile.cmake
 core.*
+gmon.out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,22 @@ if (WERROR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 endif ()
 
+# Turn gprof profiling on
+if (PROFILING)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pg")
+endif ()
+
+# O2 optimizations
+if (O2)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+endif ()
+# O3 optimizations - will override O2 if set
+if (O3)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+endif ()
+
 message(STATUS "Compiler: ${CMAKE_C_COMPILER} version: ${CMAKE_C_COMPILER_VERSION}")
 message(STATUS "Compiler: ${CMAKE_CXX_COMPILER} version: ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "Compiler flags: ${CMAKE_CXX_FLAGS}")

--- a/vme/src/descriptor_data.cpp
+++ b/vme/src/descriptor_data.cpp
@@ -300,7 +300,7 @@ const char *descriptor_data::getLastCommand() const
 
 void descriptor_data::setLastCommand(const char *value)
 {
-    strncpy(last_cmd, value, sizeof(last_cmd));
+    strncpy(last_cmd, value, sizeof(last_cmd) - 1);
 }
 
 char *descriptor_data::getCommandHistory()
@@ -310,7 +310,7 @@ char *descriptor_data::getCommandHistory()
 
 void descriptor_data::setCommandHistory(const char *value)
 {
-    strncpy(history, value, sizeof(history));
+    strncpy(history, value, sizeof(history) - 1);
 }
 
 cQueue &descriptor_data::getInputQueue()

--- a/vme/src/namelist.cpp
+++ b/vme/src/namelist.cpp
@@ -288,7 +288,6 @@ cNamelist *cNamelist::Duplicate()
     return pNl;
 }
 
-
 // See IsNameRaw.
 // Will match non-full words, so
 //   {"fallow deer", "deer"}.IsNameRawAbbrev("de guard")
@@ -334,7 +333,7 @@ const char *cNamelist::IsNameRawAbbrev(const char *name) const
 // Find a match for 'name' in this namelist.
 // Will match full name only.
 // Case insensitive.
-// Then it will return a pointer to "Boar" because there was 
+// Then it will return a pointer to "Boar" because there was
 // a match on the full word fallow.
 //
 // If name is nullptr function returns nullptr.
@@ -359,7 +358,7 @@ const char *cNamelist::IsNameRaw(const char *name) const
 
     if (name == nullptr)
         return nullptr;
-        
+
     for (i = 0; i < length; i++)
     {
         for (j = 0; namelist[i]->c_str()[j]; j++)
@@ -383,7 +382,6 @@ const char *cNamelist::IsNameRaw(const char *name) const
     return nullptr;
 }
 
-
 /* Returns -1 if no name matches, or 0.. for the index in the namelist */
 const int cNamelist::IsNameRawIdx(const char *name)
 {
@@ -392,7 +390,7 @@ const int cNamelist::IsNameRawIdx(const char *name)
 
     if (name == nullptr)
         return -1;
-        
+
     for (i = 0; i < length; i++)
     {
         for (j = 0; namelist[i]->c_str()[j]; j++)
@@ -417,7 +415,7 @@ const int cNamelist::IsNameRawIdx(const char *name)
 
 const char *cNamelist::IsName(const char *name)
 {
-    char buf[MAX_STRING_LENGTH];
+    static char buf[MAX_STRING_LENGTH];
 
     if (name == nullptr)
         return nullptr;

--- a/vme/src/vmc/vmcpar.y
+++ b/vme/src/vmc/vmcpar.y
@@ -309,9 +309,9 @@ exit_field  : TO reference
     | KEY reference
     {
         strncpy(tzone, $2, 30);
-        tzone[30] = 0;
+        tzone[29] = 0;
         strncpy(tname, $2 + strlen((char *)$2) + 1, 30);
-        tname[30] = 0;
+        tname[29] = 0;
         char *key=(char *)malloc(strlen(tzone) + strlen(tname) + 2);
         strcpy(key, (char *)tzone);
         strcpy(key + strlen(tzone) + 1, (char *)tname);
@@ -789,9 +789,9 @@ unit_field  : NAMES stringlist
     | KEY reference
     {
         strncpy(tzone, $2, 30);
-        tzone[30] = 0;
+        tzone[29] = 0;
         strncpy(tname, $2 + strlen((char *)$2) + 1, 30);
-        tname[30] = 0;
+        tname[29] = 0;
         auto *key_reference = (char *)malloc(strlen(tzone) + strlen(tname) + 2);
         strcpy(key_reference, (char *)tzone);
         strcpy(key_reference + strlen(tzone) + 1, (char *)tname);


### PR DESCRIPTION
Fixed a couple of warnings that appear when compiling with
optimzations

New cmake cmdline options

'-DPROFILING=1'      - turn on profling instrumentation for build
'-DO2=1' or '-DO3=1' - turn on -O2 or -O3 compiler optomizations