### PR TITLE
Spell and skill changes for boosting spells and skill, Re-enable morph, fix for energy worms

### DIFF
--- a/vme/zone/basis.zon
+++ b/vme/zone/basis.zon
@@ -4038,8 +4038,9 @@ code
         nCount := nCount + 1;
         s := u.symname;
 
-        // Don't consume players or player's corpses :o)
-        if ((u.type == UNIT_ST_PC) or (s == "corpse@death"))
+        // Don't consume players, player's corpses, or containers :o)
+        if ((u.type == UNIT_ST_PC) or (s == "corpse@death") or ((u.type == UNIT_ST_OBJ) and (u.objecttype==ITEM_CONTAINER)))
+
         {
             u := u.next;
             continue;

--- a/vme/zone/newbie.zon
+++ b/vme/zone/newbie.zon
@@ -742,10 +742,16 @@ block;
 
 act("Magic Newbie guardians knock you unconscious.",
 A_ALWAYS,self,null,activator,TO_VICT);
-activator.position:=POSITION_STUNNED;
-self.position:=POSITION_STANDING;
-activator.hp:=0;
-goto start;
+if (activator.type ==UNIT_ST_NPC){
+            act("As $2n attacks $1n $2e is dissolved in a bright light.", A_SOMEONE, self, activator, null, TO_ROOM);
+	destroy(activator);
+	goto start;
+} else {
+	activator.position:=POSITION_STUNNED;
+	self.position:=POSITION_STANDING;
+	activator.hp:=0;
+	goto start;
+}
 }
 dilend
 

--- a/vme/zone/rebirth.zon
+++ b/vme/zone/rebirth.zon
@@ -745,7 +745,7 @@ code
 }
 dilend /* demon_special */
 
-/*dilbegin aware recall dragon_special();
+dilbegin aware recall dragon_special();
 
 var
    targ : unitptr;
@@ -889,7 +889,7 @@ code
 
    goto start;
 }
-dilend  dragon_special */
+dilend  /*dragon_special*/
 
 dilbegin aware recall lion_special();
 
@@ -3191,7 +3191,7 @@ code
    i := dildestroy ("vampire_special@rebirth", self);
    i := dildestroy ("vampire_combat@rebirth", self);
    i := dildestroy ("no_wear@rebirth", self);
-   i := dildestroy ("morph_commands@rebirth", self);
+   i := dildestroy ("d_commands@rebirth", self);
 
    position_update(self);
 
@@ -3598,15 +3598,6 @@ var
 
 code
 {
-/* rem out below to put back in */
-
-  act("Morph has been temporarily disabled due to problems " +
-       "with some morphs being unbalanced against others. " +
-	   "As well as other issues. This will be fixed asap.",
-       A_ALWAYS, self, null, null, TO_CHAR);
-   subextra(self.extra, "$morphed");
-   quit;
-//to here
    if ((isset(self.pcflags, PC_PK_RELAXED)) and ("$Rebirth_Bob" in
         self.quests)) 
 

--- a/vme/zone/skills.zon
+++ b/vme/zone/skills.zon
@@ -12286,6 +12286,7 @@ dilbegin ski_berserk(arg : string);
 external
     integer skillchecksa(skillidx : integer, abiidx : integer, difficulty : integer);
     integer bonusCalc(hm : integer);
+    integer max@function(a:integer, b:integer);
 var
 	heal : integer;
 	hm : integer;
@@ -12327,9 +12328,7 @@ code
 	}
 	// Wrong, because NPC doesn't have SKI_BERSERK. hm := skillroll(self.abilities[ABIL_CON],30,self.skills[SKI_BERSERK],30);
     hm := skillchecksa(SKI_BERSERK, ABIL_CON, 30);
-    	
-	hm := bonusCalc(hm);
-	
+    		
 	if (hm <= 0)
 	{
 		act("<div class='spell'>You channel your energy, but fail to go berserk.</div>",
@@ -12340,6 +12339,8 @@ code
 		quit;
 	}
 	
+	hm := bonusCalc(hm);
+	
 	act("<div class='spell'>You channel your energy, and go berserk!</div>",
 		A_ALWAYS, self, null, tgt, TO_CHAR);
 	act("<div class='spell'>$1n channels their energy, and goes berserk!</div>",
@@ -12347,9 +12348,9 @@ code
 	if (isaff(tgt, ID_SPEED))
 		act("<div class='cpw'>Nothing happens.</div>",A_ALWAYS, self, null, tgt, TO_CHAR);
 	else
-	addaff(tgt, ID_BERSERK, hm*2, WAIT_SEC*30, +6, 0, 0, TIF_SPEED_BETTER, TIF_NONE, TIF_SPEED_WORSE, APF_SPEED);
-	addaff(tgt, ID_BERSERK, hm*2, WAIT_SEC*30, ABIL_CON, hm, 0, TIF_CON_INC, TIF_NONE, TIF_CON_DEC, APF_ABILITY);
-	addaff(tgt, ID_BERSERK, hm*2, WAIT_SEC*30, ABIL_HP, hm, 0, TIF_HIT_INC, TIF_NONE, TIF_HIT_DEC, APF_ABILITY);
+	addaff(tgt, ID_BERSERK, max@function(20,hm*2), WAIT_SEC*30, +6, 0, 0, TIF_SPEED_BETTER, TIF_NONE, TIF_SPEED_WORSE, APF_SPEED);
+	addaff(tgt, ID_BERSERK, max@function(20,hm*2), WAIT_SEC*30, ABIL_CON, hm, 0, TIF_CON_INC, TIF_NONE, TIF_CON_DEC, APF_ABILITY);
+	addaff(tgt, ID_BERSERK, max@function(20,hm*2), WAIT_SEC*30, ABIL_HP, hm, 0, TIF_HIT_INC, TIF_NONE, TIF_HIT_DEC, APF_ABILITY);
 	hm := hm * rnd(4,2);
     if (hm > 20) hm := 20;
 	heal := tgt.hp + (hm * 3);

--- a/vme/zone/skills.zon
+++ b/vme/zone/skills.zon
@@ -12285,7 +12285,7 @@ dilend // defending
 dilbegin ski_berserk(arg : string);
 external
     integer skillchecksa(skillidx : integer, abiidx : integer, difficulty : integer);
-
+    integer bonusCalc(hm : integer);
 var
 	heal : integer;
 	hm : integer;
@@ -12298,7 +12298,7 @@ code
       As a result the character's Speed, HP, and CON are increased temporarily.
       */
 	tgt := self;
-	
+
 	if ((self.type == UNIT_ST_PC) and (self.skills[SKI_BERSERK] <= 0))
 	{
       act("You must practice first.", A_ALWAYS, self, null, null, TO_CHAR);
@@ -12327,8 +12327,9 @@ code
 	}
 	// Wrong, because NPC doesn't have SKI_BERSERK. hm := skillroll(self.abilities[ABIL_CON],30,self.skills[SKI_BERSERK],30);
     hm := skillchecksa(SKI_BERSERK, ABIL_CON, 30);
-	if (hm > 10)
-        hm := 10;	
+    	
+	hm := bonusCalc(hm);
+	
 	if (hm <= 0)
 	{
 		act("<div class='spell'>You channel your energy, but fail to go berserk.</div>",
@@ -12346,14 +12347,14 @@ code
 	if (isaff(tgt, ID_SPEED))
 		act("<div class='cpw'>Nothing happens.</div>",A_ALWAYS, self, null, tgt, TO_CHAR);
 	else
-	addaff(tgt, ID_BERSERK, 20, WAIT_SEC*30, +6, 0, 0, TIF_SPEED_BETTER, TIF_NONE, TIF_SPEED_WORSE, APF_SPEED);
-	addaff(tgt, ID_BERSERK, 20, WAIT_SEC*30, ABIL_CON, hm, 0, TIF_CON_INC, TIF_NONE, TIF_CON_DEC, APF_ABILITY);
-	addaff(tgt, ID_BERSERK, 20, WAIT_SEC*30, ABIL_HP, hm, 0, TIF_HIT_INC, TIF_NONE, TIF_HIT_DEC, APF_ABILITY);
+	addaff(tgt, ID_BERSERK, hm*2, WAIT_SEC*30, +6, 0, 0, TIF_SPEED_BETTER, TIF_NONE, TIF_SPEED_WORSE, APF_SPEED);
+	addaff(tgt, ID_BERSERK, hm*2, WAIT_SEC*30, ABIL_CON, hm, 0, TIF_CON_INC, TIF_NONE, TIF_CON_DEC, APF_ABILITY);
+	addaff(tgt, ID_BERSERK, hm*2, WAIT_SEC*30, ABIL_HP, hm, 0, TIF_HIT_INC, TIF_NONE, TIF_HIT_DEC, APF_ABILITY);
 	hm := hm * rnd(4,2);
     if (hm > 20) hm := 20;
 	heal := tgt.hp + (hm * 3);
 	if (heal > tgt.max_hp) heal := tgt.max_hp;
-	tgt.endurance := tgt.endurance - 100;
+	tgt.endurance := tgt.endurance - (100 - (hm*2));
 	tgt.hp := heal;
 	
 	send_done("berserk",self,null,tgt,hm,arg,null, CMD_AUTO_NONE);
@@ -13035,6 +13036,28 @@ code
 dilend
 
 /* END Barbarian Skills */
+
+/*
+New function for handling bonus calculations for skills.
+Starts with the base (10) at 10 and adds anoth 1 for every 10 beyond that. This was derived
+from the berserk skill calculation.
+*/
+dilbegin integer bonusCalc(hm : integer);
+
+external
+     integer min@function(a:integer, b:integer);
+
+code
+{
+      
+      if (hm>30)
+	return(10+((hm-30)/30)); // allows for numbers greater than 10 at intervals of 30 per increase
+     else
+     	return(min@function(hm, 10));
+      
+}
+dilend
+
 %rooms
                                    skill_room
 title "The Skill Room"

--- a/vme/zone/spells.zon
+++ b/vme/zone/spells.zon
@@ -14900,7 +14900,7 @@ relevant attribute + an open100 roll -50.
 Example: Character with 50 magic and 50 skill and rolls a 50 would have a total of 100.
 1-10 are roughly 1 point per 10 points on your roll
 In this case, this function would return 10, the old standard roll.
-However, if the same character were to roll a 160 (due to how open roll works. If you roll a 100 it rolls again and adds the result so here I'm assuming they rolled a 100, then a 10) then the after the first 10 points, the second part of the calculation would kick in and the result would be an 11.
+However, if the same character were to roll a 160 (due to how open roll works. If you roll a 100 it rolls again and adds the result so here I'm assuming they rolled a 100, then a 10) then the after the first 10 points, the second part of the calculation would kick in and the result would be an 12.
 */
 dilbegin integer bonusCalc(hm : integer);
 
@@ -14908,7 +14908,7 @@ code
 {
       hm := hm/10+1;  // old starting calculation
       if (hm>10)
-	hm := 10+((hm-10)/3); // allows for numbers greater than 10 at intervals of 50 per increase
+	hm := 10+((hm-10)/3); // allows for numbers greater than 10 at intervals of 30 per increase
       
      return(hm);
 }

--- a/vme/zone/spells.zon
+++ b/vme/zone/spells.zon
@@ -8449,6 +8449,7 @@ dilbegin bless(medi:unitptr, tgt : unitptr, arg : string,
 	       hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
    /*
@@ -8469,19 +8470,19 @@ code
 
       hm := bonusCalc(hm);
 
-   addaff(tgt, ID_BLESS, hm*2, WAIT_SEC*30,
+   addaff(tgt, ID_BLESS, max@function(10,hm), WAIT_SEC*30,
 	  ABIL_DIV, hm, 0, TIF_BLESS_ON, TIF_BLESS_TICK, TIF_BLESS_OFF,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_BLESS, hm*2, WAIT_SEC*30,
+   addaff(tgt, ID_BLESS, max@function(10,hm), WAIT_SEC*30,
 	  ABIL_DEX, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_BLESS, hm*2, WAIT_SEC*30,
+   addaff(tgt, ID_BLESS, max@function(10,hm), WAIT_SEC*30,
 	  ABIL_STR, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_BLESS, hm*2, WAIT_SEC*30,
+   addaff(tgt, ID_BLESS, max@function(10,hm), WAIT_SEC*30,
 	  ABIL_BRA, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
 
@@ -8499,6 +8500,7 @@ dilend
 dilbegin ubless(medi:unitptr,tgt:unitptr,arg:string,hm:integer,effect:string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
    /*
@@ -8519,19 +8521,19 @@ code
 
       hm := bonusCalc(hm);
 
-   addaff(tgt, ID_UNHOLY_BLESSING, hm*2, WAIT_SEC*30,
+   addaff(tgt, ID_UNHOLY_BLESSING, max@function(10,hm), WAIT_SEC*30,
 	  ABIL_DIV, hm, 0, TIF_BLESS_ON, TIF_BLESS_TICK, TIF_BLESS_OFF,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_UNHOLY_BLESSING, hm*2, WAIT_SEC*30,
+   addaff(tgt, ID_UNHOLY_BLESSING, max@function(10,hm), WAIT_SEC*30,
 	  ABIL_DEX, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_UNHOLY_BLESSING, hm*2, WAIT_SEC*30,
+   addaff(tgt, ID_UNHOLY_BLESSING, max@function(10,hm), WAIT_SEC*30,
 	  ABIL_STR, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_UNHOLY_BLESSING, hm*2, WAIT_SEC*30,
+   addaff(tgt, ID_UNHOLY_BLESSING, max@function(10,hm), WAIT_SEC*30,
 	  ABIL_BRA, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
    quit;
@@ -8615,6 +8617,7 @@ dilbegin raise_div(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -8634,7 +8637,7 @@ if ((isaff(tgt,ID_SPL_RAISE_DIV)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_DIV, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_DIV, max@function(20,hm*2), WAIT_SEC*30,
 	       ABIL_DIV, hm, 0, TIF_DIV_INC, TIF_NONE, TIF_DIV_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8649,6 +8652,7 @@ dilbegin raise_mag(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -8668,7 +8672,7 @@ if ((isaff(tgt,ID_SPL_RAISE_MAG)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_MAG, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_MAG, max@function(20,hm*2), WAIT_SEC*30,
 	       ABIL_MAG, hm, 0, TIF_MAG_INC, TIF_NONE, TIF_MAG_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8683,6 +8687,7 @@ dilbegin raise_str(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 
 code
 {
@@ -8704,7 +8709,7 @@ if ((isaff(tgt,ID_SPL_RAISE_STR)) or
          
       hm := bonusCalc(hm);
 	
-	addaff(tgt, ID_SPL_RAISE_STR, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_STR, max@function(20,hm*2), WAIT_SEC*30,
 	       ABIL_STR, hm, 0, TIF_STR_INC, TIF_NONE, TIF_STR_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8719,6 +8724,7 @@ dilbegin raise_dex(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -8738,7 +8744,7 @@ if ((isaff(tgt,ID_SPL_RAISE_DEX)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_DEX, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_DEX, max@function(20,hm*2), WAIT_SEC*30,
 	       ABIL_DEX, hm, 0, TIF_DEX_INC, TIF_NONE, TIF_DEX_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8753,6 +8759,7 @@ dilbegin raise_con(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -8772,7 +8779,7 @@ if ((isaff(tgt,ID_SPL_RAISE_CON)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_CON, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_CON, max@function(20,hm*2), WAIT_SEC*30,
 	       ABIL_CON, hm, 0, TIF_CON_INC, TIF_NONE, TIF_CON_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8786,6 +8793,7 @@ dilbegin raise_cha(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -8805,7 +8813,7 @@ if ((isaff(tgt,ID_SPL_RAISE_CHA)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_CHA, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_CHA, max@function(20,hm*2), WAIT_SEC*30,
 	       ABIL_CHA, hm, 0, TIF_CHA_INC, TIF_NONE, TIF_CHA_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8820,6 +8828,7 @@ dilbegin raise_bra(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -8839,7 +8848,7 @@ if ((isaff(tgt,ID_SPL_RAISE_BRA)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_BRA, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_BRA, max@function(20,hm*2), WAIT_SEC*30,
 	       ABIL_BRA, hm, 0, TIF_BRA_INC, TIF_NONE, TIF_BRA_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8855,6 +8864,7 @@ dilbegin raise_divine(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -8874,7 +8884,7 @@ if ((isaff(tgt,ID_SPL_RAISE_DIVINE)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_DIVINE, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_DIVINE, max@function(20,hm*2), WAIT_SEC*30,
 	       SPL_DIVINE, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -8889,6 +8899,7 @@ dilbegin raise_heat(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -8908,7 +8919,7 @@ if ((isaff(tgt,ID_SPL_RAISE_HEAT)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_HEAT, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_HEAT, max@function(20,hm*2), WAIT_SEC*30,
 	       SPL_HEAT, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -8923,6 +8934,7 @@ dilbegin raise_summoning(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -8942,7 +8954,7 @@ if ((isaff(tgt,ID_SPL_RAISE_SUMMONING)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_SUMMONING, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_SUMMONING, max@function(20,hm*2), WAIT_SEC*30,
 	       SPL_SUMMONING, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -8957,6 +8969,7 @@ dilbegin raise_cold(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -8976,7 +8989,7 @@ if ((isaff(tgt,ID_SPL_RAISE_COLD)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_COLD, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_COLD, max@function(20,hm*2), WAIT_SEC*30,
 	       SPL_COLD, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -8991,6 +9004,7 @@ dilbegin raise_elect(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -9010,7 +9024,7 @@ if ((isaff(tgt,ID_SPL_RAISE_CELL)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_CELL, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_CELL, max@function(20,hm*2), WAIT_SEC*30,
 	       SPL_CELL, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -9025,6 +9039,7 @@ dilbegin raise_poison(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -9044,7 +9059,7 @@ if ((isaff(tgt,ID_SPL_RAISE_INTERNAL)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_INTERNAL, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_INTERNAL, max@function(20,hm*2), WAIT_SEC*30,
 	       SPL_INTERNAL, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -9059,6 +9074,7 @@ dilbegin raise_acid(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -9078,7 +9094,7 @@ if ((isaff(tgt,ID_SPL_RAISE_EXTERNAL)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_EXTERNAL, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_EXTERNAL, max@function(20,hm*2), WAIT_SEC*30,
 	       SPL_EXTERNAL, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -9093,6 +9109,7 @@ dilbegin mind_shield(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
+     iinteger max@function(a:integer, b:integer);
 code
 {
 
@@ -9112,7 +9129,7 @@ if ((isaff(tgt,ID_SPL_RAISE_MIND)) or
 
       hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_MIND, hm*2, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_MIND, max@function(20,hm*2), WAIT_SEC*30,
 	       SPL_MIND, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")

--- a/vme/zone/spells.zon
+++ b/vme/zone/spells.zon
@@ -8449,7 +8449,7 @@ dilbegin bless(medi:unitptr, tgt : unitptr, arg : string,
 	       hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
    /*
@@ -8500,7 +8500,7 @@ dilend
 dilbegin ubless(medi:unitptr,tgt:unitptr,arg:string,hm:integer,effect:string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
    /*
@@ -8617,7 +8617,7 @@ dilbegin raise_div(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -8652,7 +8652,7 @@ dilbegin raise_mag(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -8687,7 +8687,7 @@ dilbegin raise_str(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 
 code
 {
@@ -8724,7 +8724,7 @@ dilbegin raise_dex(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -8759,7 +8759,7 @@ dilbegin raise_con(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -8793,7 +8793,7 @@ dilbegin raise_cha(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -8828,7 +8828,7 @@ dilbegin raise_bra(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -8864,7 +8864,7 @@ dilbegin raise_divine(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -8899,7 +8899,7 @@ dilbegin raise_heat(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -8934,7 +8934,7 @@ dilbegin raise_summoning(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -8969,7 +8969,7 @@ dilbegin raise_cold(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -9004,7 +9004,7 @@ dilbegin raise_elect(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -9039,7 +9039,7 @@ dilbegin raise_poison(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -9074,7 +9074,7 @@ dilbegin raise_acid(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 
@@ -9109,7 +9109,7 @@ dilbegin mind_shield(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
 external
      integer bonusCalc(hm : integer);
-     iinteger max@function(a:integer, b:integer);
+     integer max@function(a:integer, b:integer);
 code
 {
 

--- a/vme/zone/spells.zon
+++ b/vme/zone/spells.zon
@@ -4233,9 +4233,7 @@ dilbegin integer skill_duration(hm : integer);
 code
 {
    if (hm < 20)
-     return (2);
-   else if (hm > 150)
-     return (15);
+     return (2); // removed cap at 150 of 15.
    else
      return (hm / 10);
 }
@@ -5046,8 +5044,15 @@ code
       i := i + 1;
 
       self.hp := self.hp - j;
+      
       self.mana := self.mana - 2*j;
+      if (self.mana < 0)
+      	self.mana := 0;	
+
       self.endurance := self.endurance - 2*j;
+      if (self.endurance < 0)
+        self.endurance := 0;
+      
       if (self.hp >= -10)
           position_update(self);
 
@@ -6143,9 +6148,8 @@ code
         i := i + 1;
     }
 
-    /* Finally copy in the description from $identify / $improved identify
-       added <br/> to allow new line for improved identify for old items instead
-       of running indentification strings together */
+    // Finally copy in the description from $identify / $improved identify
+
     exd := "$identify" in tgt.extra;
     if (exd)
         s := exd.descr + s;
@@ -6154,7 +6158,7 @@ code
     {
         exd := "$improved identify" in tgt.extra;
         if (exd)
-            s := exd.descr + "<br/>" + s;
+            s := exd.descr + s;
     }
 
     return(s);
@@ -8439,6 +8443,8 @@ dilend
 
 dilbegin bless(medi:unitptr, tgt : unitptr, arg : string,
 	       hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
    /*
@@ -8457,23 +8463,21 @@ code
       quit;
    }
 
-   hm := 1 + hm / 10;
-   if (hm > 10)
-      hm := 10;
+      hm := bonusCalc(hm);
 
-   addaff(tgt, ID_BLESS, 10, WAIT_SEC*30,
+   addaff(tgt, ID_BLESS, hm*2, WAIT_SEC*30,
 	  ABIL_DIV, hm, 0, TIF_BLESS_ON, TIF_BLESS_TICK, TIF_BLESS_OFF,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_BLESS, 10, WAIT_SEC*30,
+   addaff(tgt, ID_BLESS, hm*2, WAIT_SEC*30,
 	  ABIL_DEX, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_BLESS, 10, WAIT_SEC*30,
+   addaff(tgt, ID_BLESS, hm*2, WAIT_SEC*30,
 	  ABIL_STR, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_BLESS, 10, WAIT_SEC*30,
+   addaff(tgt, ID_BLESS, hm*2, WAIT_SEC*30,
 	  ABIL_BRA, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
 
@@ -8489,6 +8493,8 @@ code
 dilend
 
 dilbegin ubless(medi:unitptr,tgt:unitptr,arg:string,hm:integer,effect:string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
    /*
@@ -8507,22 +8513,21 @@ code
       quit;
    }
 
-   hm := 1 + hm / 10;
-   if (hm > 10) hm := 10;
+      hm := bonusCalc(hm);
 
-   addaff(tgt, ID_UNHOLY_BLESSING, 10, WAIT_SEC*30,
+   addaff(tgt, ID_UNHOLY_BLESSING, hm*2, WAIT_SEC*30,
 	  ABIL_DIV, hm, 0, TIF_BLESS_ON, TIF_BLESS_TICK, TIF_BLESS_OFF,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_UNHOLY_BLESSING, 10, WAIT_SEC*30,
+   addaff(tgt, ID_UNHOLY_BLESSING, hm*2, WAIT_SEC*30,
 	  ABIL_DEX, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_UNHOLY_BLESSING, 10, WAIT_SEC*30,
+   addaff(tgt, ID_UNHOLY_BLESSING, hm*2, WAIT_SEC*30,
 	  ABIL_STR, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
 
-   addaff(tgt, ID_UNHOLY_BLESSING, 10, WAIT_SEC*30,
+   addaff(tgt, ID_UNHOLY_BLESSING, hm*2, WAIT_SEC*30,
 	  ABIL_BRA, hm, 0, TIF_NONE, TIF_NONE, TIF_NONE,
 	  APF_ABILITY);
    quit;
@@ -8604,6 +8609,8 @@ dilend
 
 dilbegin raise_div(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8621,11 +8628,9 @@ if ((isaff(tgt,ID_SPL_RAISE_DIV)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_DIV, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_DIV, hm*2, WAIT_SEC*30,
 	       ABIL_DIV, hm, 0, TIF_DIV_INC, TIF_NONE, TIF_DIV_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8638,6 +8643,8 @@ dilend
 
 dilbegin raise_mag(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8655,11 +8662,9 @@ if ((isaff(tgt,ID_SPL_RAISE_MAG)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_MAG, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_MAG, hm*2, WAIT_SEC*30,
 	       ABIL_MAG, hm, 0, TIF_MAG_INC, TIF_NONE, TIF_MAG_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8672,6 +8677,9 @@ dilend
 
 dilbegin raise_str(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
+
 code
 {
 
@@ -8688,12 +8696,11 @@ if ((isaff(tgt,ID_SPL_RAISE_STR)) or
          effect(tgt, medi, -1);
          quit;
          }
-
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
-
-	addaff(tgt, ID_SPL_RAISE_STR, 20, WAIT_SEC*30,
+         
+         
+      hm := bonusCalc(hm);
+	
+	addaff(tgt, ID_SPL_RAISE_STR, hm*2, WAIT_SEC*30,
 	       ABIL_STR, hm, 0, TIF_STR_INC, TIF_NONE, TIF_STR_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8706,6 +8713,8 @@ dilend
 
 dilbegin raise_dex(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8723,11 +8732,9 @@ if ((isaff(tgt,ID_SPL_RAISE_DEX)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_DEX, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_DEX, hm*2, WAIT_SEC*30,
 	       ABIL_DEX, hm, 0, TIF_DEX_INC, TIF_NONE, TIF_DEX_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8740,6 +8747,8 @@ dilend
 
 dilbegin raise_con(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8757,11 +8766,9 @@ if ((isaff(tgt,ID_SPL_RAISE_CON)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_CON, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_CON, hm*2, WAIT_SEC*30,
 	       ABIL_CON, hm, 0, TIF_CON_INC, TIF_NONE, TIF_CON_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8773,6 +8780,8 @@ if ((isaff(tgt,ID_SPL_RAISE_CON)) or
 dilend
 dilbegin raise_cha(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8790,11 +8799,9 @@ if ((isaff(tgt,ID_SPL_RAISE_CHA)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_CHA, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_CHA, hm*2, WAIT_SEC*30,
 	       ABIL_CHA, hm, 0, TIF_CHA_INC, TIF_NONE, TIF_CHA_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8807,6 +8814,8 @@ dilend
 
 dilbegin raise_bra(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8824,11 +8833,9 @@ if ((isaff(tgt,ID_SPL_RAISE_BRA)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_BRA, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_BRA, hm*2, WAIT_SEC*30,
 	       ABIL_BRA, hm, 0, TIF_BRA_INC, TIF_NONE, TIF_BRA_DEC,
 	       APF_ABILITY);
    if (effect != "")
@@ -8842,6 +8849,8 @@ dilend
 
 dilbegin raise_divine(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8859,11 +8868,9 @@ if ((isaff(tgt,ID_SPL_RAISE_DIVINE)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_DIVINE, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_DIVINE, hm*2, WAIT_SEC*30,
 	       SPL_DIVINE, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -8876,6 +8883,8 @@ dilend
 
 dilbegin raise_heat(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8893,11 +8902,9 @@ if ((isaff(tgt,ID_SPL_RAISE_HEAT)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_HEAT, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_HEAT, hm*2, WAIT_SEC*30,
 	       SPL_HEAT, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -8910,6 +8917,8 @@ dilend
 
 dilbegin raise_summoning(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8927,11 +8936,9 @@ if ((isaff(tgt,ID_SPL_RAISE_SUMMONING)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_SUMMONING, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_SUMMONING, hm*2, WAIT_SEC*30,
 	       SPL_SUMMONING, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -8944,6 +8951,8 @@ dilend
 
 dilbegin raise_cold(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8961,11 +8970,9 @@ if ((isaff(tgt,ID_SPL_RAISE_COLD)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_COLD, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_COLD, hm*2, WAIT_SEC*30,
 	       SPL_COLD, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -8978,6 +8985,8 @@ dilend
 
 dilbegin raise_elect(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -8995,11 +9004,9 @@ if ((isaff(tgt,ID_SPL_RAISE_CELL)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_CELL, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_CELL, hm*2, WAIT_SEC*30,
 	       SPL_CELL, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -9012,6 +9019,8 @@ dilend
 
 dilbegin raise_poison(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -9029,11 +9038,9 @@ if ((isaff(tgt,ID_SPL_RAISE_INTERNAL)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_INTERNAL, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_INTERNAL, hm*2, WAIT_SEC*30,
 	       SPL_INTERNAL, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -9046,6 +9053,8 @@ dilend
 
 dilbegin raise_acid(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -9063,11 +9072,9 @@ if ((isaff(tgt,ID_SPL_RAISE_EXTERNAL)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_EXTERNAL, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_EXTERNAL, hm*2, WAIT_SEC*30,
 	       SPL_EXTERNAL, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -9080,6 +9087,8 @@ dilend
 
 dilbegin mind_shield(medi:unitptr, tgt : unitptr, arg : string,
 	           hm : integer, effect : string);
+external
+     integer bonusCalc(hm : integer);
 code
 {
 
@@ -9097,11 +9106,9 @@ if ((isaff(tgt,ID_SPL_RAISE_MIND)) or
          quit;
          }
 
-      hm := hm/10+1;
-      if (hm>10)
-	hm := 10;
+      hm := bonusCalc(hm);
 
-	addaff(tgt, ID_SPL_RAISE_MIND, 20, WAIT_SEC*30,
+	addaff(tgt, ID_SPL_RAISE_MIND, hm*2, WAIT_SEC*30,
 	       SPL_MIND, hm, 0, TIF_PROTECT_INC, TIF_NONE, TIF_PROTECT_DEC,
 	       APF_SPELL_ADJ);
    if (effect != "")
@@ -14880,6 +14887,29 @@ code
 }
 dilend
 
+/*
+New function for handling bonus calculations.
+Uses the old code as a starting point for bonuses of up to 10 points but removes the cap,
+allowing bonuses over 10 if the roll is high enough.
+Remember that rolls for attribute boosts are generally the sum of the characters skill and
+relevant attribute + an open100 roll -50.
+Example: Character with 50 magic and 50 skill and rolls a 50 would have a total of 100.
+1-10 are roughly 1 point per 10 points on your roll
+In this case, this function would return 10, the old standard roll.
+However, if the same character were to roll a 160 (due to how open roll works. If you roll a 100 it rolls again and adds the result so here I'm assuming they rolled a 100, then a 10) then the after the first 10 points, the second part of the calculation would kick in and the result would be an 11.
+*/
+dilbegin integer bonusCalc(hm : integer);
+
+code
+{
+      hm := hm/10+1;  // old starting calculation
+      if (hm>10)
+	hm := 10+((hm-10)/5); // allows for numbers greater than 10 at intervals of 50 per increase
+      
+     return(hm);
+}
+dilend
+
 %rooms
 
                                    spell_room
@@ -15390,3 +15420,4 @@ end
 
 
 %end
+

--- a/vme/zone/spells.zon
+++ b/vme/zone/spells.zon
@@ -4238,7 +4238,7 @@ code
    else if (hm <= 150)
       return (hm/10);
    else
-      return (15+((hm-150)/50));
+      return (15+((hm-150)/20));
 
 }
 dilend
@@ -14908,7 +14908,7 @@ code
 {
       hm := hm/10+1;  // old starting calculation
       if (hm>10)
-	hm := 10+((hm-10)/5); // allows for numbers greater than 10 at intervals of 50 per increase
+	hm := 10+((hm-10)/3); // allows for numbers greater than 10 at intervals of 50 per increase
       
      return(hm);
 }

--- a/vme/zone/spells.zon
+++ b/vme/zone/spells.zon
@@ -4232,10 +4232,14 @@ dilend
 dilbegin integer skill_duration(hm : integer);
 code
 {
+
    if (hm < 20)
-     return (2); // removed cap at 150 of 15.
+      return (2);
+   else if (hm <= 150)
+      return (hm/10);
    else
-     return (hm / 10);
+      return (15+((hm-150)/50));
+
 }
 dilend
 dilbegin unitptr unit_room(u : unitptr);

--- a/vme/zone/update.zon
+++ b/vme/zone/update.zon
@@ -555,8 +555,7 @@ else if (tlist.[i]==left("maxmana",length(tlist.[i])))
   addstring (plist,"%tankdiag%");
        tlist.[i]:="%tankdiag%";
     }
-  else   if ((tlist.[i]==left("zone",length(tlist.[i]))) and
-(self.level >= IMMORTAL_LEVEL))
+  else   if (tlist.[i]==left("zone",length(tlist.[i])))
   {
     if (not("%zone%" in  plist))
   addstring (plist,"%zone%");


### PR DESCRIPTION
Changes boost spells to allow benefit to having higher amounts of skill or spell power when casting.
New calculation is hm := hm/10+1;
      if (hm>10)
    hm := 10+((hm-10)/5)
This keeps the old calculation for lower level casting while allowing benefit at a massively reduced rate for those who are highly skilled and magically/divinely trained.
This also affects duration whic has been switched to hm*2. This means in a few cases you will need to cast more often but most of time time it will be a positive change.
Morphg also re-enabled. Most of the reasons it was disabled are no longer relevant to the mud in its current state.