### PR TITLE
Add docker-compose alternative and allow websocket host override

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,59 @@ See 'docker run --help'.
 32:DOCKER_CONTENT_TRUST=1
 [user@localhost]$ DOCKER_CONTENT_TRUST=0 docker run -d -p 4280:4280 dikumud3
 ```
+
+## Docker Compose
+
+Alternative to docker, you may use docker-compose.
+
+1. Build the image
+```console
+docker-compose build
+```
+
+2. Modify the docker-compose.yaml file to your needs, there are two variables you may set:
+   - WS_HOST: The host the websocket server will bind to.  By default, it is set to localhost.
+   - WS_PORT: The port the websocket server will bind to.  By default, it is set to 4280.
+
+For example in `docker-compose.yaml`:
+```diff
+version: '3.8'
+
+services:
+  dikumud3:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+-      - "4280:4280"
++      - "34280:34280"
+      - "80:80"
+    environment:
+-      - WS_HOST=localhost
+-      - WS_PORT=4280
++      - WS_HOST=ws.example.com
++      - WS_PORT=34280
+    volumes:
+      - ./vme/lib:/dikumud3/vme/lib
+```
+
+3. Modify the volume mounts to your needs.  By default, it is set to the current directory for persisting the mud data.
+
+4. Run the container
+```console
+docker-compose up
+```
+- Optionally, run it in detached mode with: `docker-compose up -d`
+
+5. For development, you can rebuild the container when you make changes by running:
+```console
+docker-compose up -d --build
+```
+
+6. When finished, stop the container with:
+```console
+docker-compose down
+```
+
+
+

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ services:
       dockerfile: Dockerfile
     ports:
 -      - "4280:4280"
-+      - "34280:34280"
++      - "34280:4280"
       - "80:80"
     environment:
 -      - WS_HOST=localhost

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  dikumud3:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "4280:4280"
+      - "80:80"
+    environment:
+      - WS_HOST=localhost
+      - WS_PORT=4280
+    volumes:
+      - ./vme/lib:/dikumud3/vme/lib

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,5 +11,6 @@ services:
     environment:
       - WS_HOST=localhost
       - WS_PORT=4280
+    # Remove the volume mount below, if you do not want to persist the mud data.
     volumes:
       - ./vme/lib:/dikumud3/vme/lib

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,18 @@ function signals()
 
 trap signals INT TERM EXIT HUP
 
+
+# Override the default values if the environment variables are set.
+WS_HOST=${WS_HOST:-localhost}
+WS_PORT=${WS_PORT:-4280}
+if [ "$WS_HOST" != "localhost" ] || [ "$WS_PORT" != "4280" ] ; then
+  echo "Starting websocket server on ws://${WS_HOST}:${WS_PORT}/echo"
+  DOCKER_CLIENT_FPATH="/dikumud3/vme/www/docker/index.html"
+  sed -i "s/encodeURI('localhost')/encodeURI('${WS_HOST}')/g" ${DOCKER_CLIENT_FPATH}
+  sed -i "s/encodeURI('4280')/encodeURI('${WS_PORT}')/g" ${DOCKER_CLIENT_FPATH}
+fi
+
+# Start services.
 service nginx restart
 cd /dikumud3/vme/bin
 rm -f vme.log mplex.log


### PR DESCRIPTION
Allow the developer to use docker-compose as an option to docker:
- By default, persist the mud data in a volume mount
- It allows overrides to the websocket host and port, which is required to host a production and a development version. This uses sed in the entrypoint to modify the `vme/www/docker/index.html` websocket connection at runtime.

README updated to include usage.