### PR TITLE
Fixes #398 Reversed ANSI red bold and dim in telnet translation

### DIFF
--- a/vme/src/mplex/translate.cpp
+++ b/vme/src/mplex/translate.cpp
@@ -125,11 +125,11 @@ void Control_ANSI_Fg(cConHook *con, char **dest, ubit8 code, int bBold)
         case 'r':
             if (bBold)
             {
-                Control_ANSI_Fg_Red(con, dest, 0);
+                Control_ANSI_Fgb_Red(con, dest, 0);
             }
             else
             {
-                Control_ANSI_Fgb_Red(con, dest, 0);
+                Control_ANSI_Fg_Red(con, dest, 0);
             }
             break;
 


### PR DESCRIPTION
Bold and dim were flipped only on red colour in telnet ANSI translations.