### PR TITLE
Fix add-name rejecting names that share a prefix with an existing name

### DIFF
--- a/unit_tests/cNamelist_tests.cpp
+++ b/unit_tests/cNamelist_tests.cpp
@@ -1425,4 +1425,77 @@ BOOST_AUTO_TEST_CASE(StrStr5_test)
     BOOST_TEST(std::string(ret) == "HOMER");
 }
 
+BOOST_AUTO_TEST_CASE(insert_name_ordered_keeps_longest_first)
+{
+    cNamelist list;
+    ////////////////////////// Test Subject //////////////////////////////
+    bool added_short = list.InsertNameOrdered("bag");
+    bool added_long = list.InsertNameOrdered("bag of tricks");
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(added_short);
+    BOOST_TEST(added_long);
+    BOOST_REQUIRE(list.Length() == 2);
+    // "bag" must never come before "bag of tricks": IsName() matching stops
+    // at the prefix and the longer name would be unreachable.
+    BOOST_TEST(std::string(list.Name(0)) == "bag of tricks");
+    BOOST_TEST(std::string(list.Name(1)) == "bag");
+}
+
+// Regression test for issue #406: a stored name that is a word-boundary
+// prefix of the new name ("bag" vs "bag of tricks") made the old
+// IsName()-based duplicate check reject the insert silently.
+BOOST_AUTO_TEST_CASE(insert_name_ordered_prefix_is_not_a_duplicate)
+{
+    const char *data[] = {"trick bag", "bag", nullptr};
+    cNamelist list(data);
+    ////////////////////////// Test Subject //////////////////////////////
+    bool added = list.InsertNameOrdered("bag of tricks");
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(added);
+    BOOST_REQUIRE(list.Length() == 3);
+    BOOST_TEST(std::string(list.Name(0)) == "bag of tricks");
+    BOOST_TEST(std::string(list.Name(1)) == "trick bag");
+    BOOST_TEST(std::string(list.Name(2)) == "bag");
+}
+
+BOOST_AUTO_TEST_CASE(insert_name_ordered_rejects_exact_duplicates)
+{
+    const char *data[] = {"bag of tricks", "bag", nullptr};
+    cNamelist list(data);
+    ////////////////////////// Test Subject //////////////////////////////
+    bool added_case = list.InsertNameOrdered("BAG");
+    bool added_spaces = list.InsertNameOrdered("  bag  ");
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(!added_case);   // case insensitive
+    BOOST_TEST(!added_spaces); // surrounding whitespace ignored
+    BOOST_TEST(list.Length() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(insert_name_ordered_rejects_empty)
+{
+    cNamelist list;
+    ////////////////////////// Test Subject //////////////////////////////
+    bool added_empty = list.InsertNameOrdered("");
+    bool added_blank = list.InsertNameOrdered("   ");
+    bool added_null = list.InsertNameOrdered(nullptr);
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(!added_empty);
+    BOOST_TEST(!added_blank);
+    BOOST_TEST(!added_null);
+    BOOST_TEST(list.Length() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(insert_name_ordered_equal_length_is_stable)
+{
+    const char *data[] = {"axe", nullptr};
+    cNamelist list(data);
+    ////////////////////////// Test Subject //////////////////////////////
+    bool added = list.InsertNameOrdered("bow");
+    ////////////////////////// Test Subject //////////////////////////////
+    BOOST_TEST(added);
+    BOOST_REQUIRE(list.Length() == 2);
+    BOOST_TEST(std::string(list.Name(0)) == "axe");
+    BOOST_TEST(std::string(list.Name(1)) == "bow");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/vme/src/modify.cpp
+++ b/vme/src/modify.cpp
@@ -363,10 +363,12 @@ int get_type(char *typdef, const char *structure[])
     return search_block_set(typdef, structure, FALSE);
 }
 
-void insert_comma_names(cNamelist *nl, char *argument)
+// Returns the number of names actually inserted (exact duplicates and empty
+// strings are skipped, see cNamelist::InsertNameOrdered()).
+int insert_comma_names(cNamelist *nl, char *argument)
 {
     if (str_is_empty(argument))
-        return;
+        return 0;
 
     argument = (char *)skip_spaces(argument);
     strip_trailing_blanks(argument);
@@ -377,13 +379,17 @@ void insert_comma_names(cNamelist *nl, char *argument)
 
     boost::split(results, text, [](char c) { return c == ','; });
 
+    int added = 0;
+
     for (int i = 0; i < (int)results.size(); i++)
     {
-        if (!nl->IsName(results[i].c_str()) && !str_is_empty(results[i].c_str()))
+        if (nl->InsertNameOrdered(results[i].c_str()))
         {
-            nl->AppendNameTrim(results[i].c_str());
+            added++;
         }
     }
+
+    return added;
 }
 
 void insert_comma_ints(cintlist *il, char *argument)
@@ -738,8 +744,14 @@ void do_set(unit_data *ch, char *argument, const command_info *cmd)
                 return;
             }
 
-            insert_comma_names(&unt->getNames(), argument);
-            send_to_char("The extra name was added.<br/>", ch);
+            if (insert_comma_names(&unt->getNames(), argument) > 0)
+            {
+                send_to_char("The extra name was added.<br/>", ch);
+            }
+            else
+            {
+                send_to_char("No name added (empty or already in the name list).<br/>", ch);
+            }
             return;
 
         case 1: /* "del-name" */

--- a/vme/src/namelist.cpp
+++ b/vme/src/namelist.cpp
@@ -724,6 +724,103 @@ void cNamelist::InsertName(const char *name, ubit32 loc)
     }
 }
 
+// Find the index of the entry matching 'name' exactly (case insensitive,
+// surrounding whitespace ignored). Unlike IsName() / IsNameRaw(), a stored
+// name that is merely a word-boundary prefix of 'name' does not match.
+// Returns -1 when no entry matches.
+int cNamelist::IsNameExactIdx(const char *name) const
+{
+    if (name == nullptr)
+    {
+        return -1;
+    }
+
+    while (isspace(*name))
+    {
+        name++;
+    }
+
+    size_t len = strlen(name);
+    while (len > 0 && isspace(name[len - 1]))
+    {
+        len--;
+    }
+
+    if (len == 0)
+    {
+        return -1;
+    }
+
+    std::string trimmed(name, len);
+
+    for (ubit32 i = 0; i < length; i++)
+    {
+        if (str_ccmp(namelist[i]->c_str(), trimmed.c_str()) == 0)
+        {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+// Insert 'name' keeping the list ordered longest-to-shortest, so that a
+// short name never shadows a longer name it is a prefix of (with
+// {"bag", "bag of tricks"} in that order, IsName("bag of tricks") stops at
+// "bag" and the longer name is unreachable).
+// Exact duplicates are not added; a stored name that is only a prefix of
+// 'name' does not count as a duplicate (issue #406).
+// Returns true when the name was inserted.
+bool cNamelist::InsertNameOrdered(const char *name)
+{
+    if (name == nullptr)
+    {
+        return false;
+    }
+
+    while (isspace(*name))
+    {
+        name++;
+    }
+
+    size_t len = strlen(name);
+    while (len > 0 && isspace(name[len - 1]))
+    {
+        len--;
+    }
+
+    if (len == 0)
+    {
+        return false;
+    }
+
+    std::string trimmed(name, len);
+    str_remspc(trimmed.data());
+    trimmed.resize(strlen(trimmed.c_str()));
+
+    if (IsNameExactIdx(trimmed.c_str()) != -1)
+    {
+        return false;
+    }
+
+    ubit32 loc = 0;
+    while (loc < length && namelist[loc]->length() >= trimmed.length())
+    {
+        loc++;
+    }
+
+    if (loc < length)
+    {
+        InsertName(trimmed.c_str(), loc);
+    }
+    else
+    {
+        AppendName(trimmed.c_str());
+    }
+
+    return true;
+}
+
 void cNamelist::toJSON(rapidjson::PrettyWriter<rapidjson::StringBuffer> &writer) const
 {
     writer.StartObject();

--- a/vme/src/namelist.h
+++ b/vme/src/namelist.h
@@ -45,11 +45,13 @@ public:
     void AppendName(const char *name);
     void PrependName(const char *name);
     void InsertName(const char *name, ubit32 loc);
+    bool InsertNameOrdered(const char *name);
 
     cNamelist *Duplicate();
 
     const int IsNameIdx(const char *name);
     const int IsNameRawIdx(const char *name);
+    int IsNameExactIdx(const char *name) const;
     const char *IsNameRaw(const char *name);
     const char *IsNameRaw(const char *name) const;
     const char *IsNameRawAbbrev(const char *name);


### PR DESCRIPTION
Fixes #406.

> [!NOTE]
> Stacked on #419 (base branch is `ubuntu-26-support`, since master doesn't build on the new toolchain). Merge #419 first; this PR then retargets to master automatically when the branch is deleted, showing only its own commit.

## The bug

`set <unit> add-name` used `cNamelist::IsName()` as its duplicate check. `IsName()` is the game's target-matching predicate — it succeeds when any stored name is a *word-boundary prefix* of the argument. So with names `{"trick bag", "bag"}`, `add-name bag of tricks` was silently skipped ("bag" prefix-matches it) while still reporting *"The extra name was added."*

Neither existing predicate could be swapped in: `IsNameRaw()`'s comment says "exact name only" but its code also accepts word-boundary prefixes.

## The fix (as suggested in the issue thread — part of the Names class)

- **`cNamelist::IsNameExactIdx()`** — true exact full-string match: case insensitive, surrounding whitespace ignored, prefixes do NOT match.
- **`cNamelist::InsertNameOrdered()`** — dedups on exact match only, and inserts sorted **longest-to-shortest**, so a short name can never shadow a longer name it is a prefix of. This also eliminates the manual `del-name`/`add-name` reordering ritual described in the issue.
- **`insert_comma_names()`** now returns how many names were actually added, and `do_set` add-name reports honestly instead of unconditionally claiming success.

Behavioral note: names added via `set add-name` (and door/extra-description names, which share `insert_comma_names`) are now inserted in length order rather than appended. Existing saved namelists are not reordered — only new insertions.

## Unit tests

Five new cases in `cNamelist_tests.cpp`, including the two that matter most:

- `insert_name_ordered_prefix_is_not_a_duplicate` — the literal issue #406 scenario: `{"trick bag", "bag"}` + "bag of tricks" must be **added**, in front.
- `insert_name_ordered_keeps_longest_first` — the ordering invariant: adding "bag" then "bag of tricks" must end up `["bag of tricks", "bag"]`; "bag" can never come before "bag of tricks".

Plus exact-duplicate rejection (case/whitespace variants), empty/blank/null input, and stable ordering for equal-length names. All 5 test suites pass; build is warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7CqwMRW1CqvQiBLrYPKqD