### PR TITLE
Convert missed dilval delete to dilval::free

### DIFF
--- a/vme/src/dilinst.cpp
+++ b/vme/src/dilinst.cpp
@@ -1068,7 +1068,7 @@ void dilfi_rtf(dilprg *p)
                     return;
                 }
 
-                delete(p->stack.pop());
+                dilval::free(p->stack.pop());
             }
         }
     }


### PR DESCRIPTION
One `delete(p->stack.pop());` (no space after `delete`) escaped the mechanical conversion in #422. Harmless — the block simply bypassed the pool and went back to the system allocator — but inconsistent with the new invariant that all dilvals go through `dilval::alloc()`/`dilval::free()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7CqwMRW1CqvQiBLrYPKqD