### PR TITLE
Fix telnet line progression on server reboot (issue #395)

### DIFF
--- a/vme/src/hookmud.cpp
+++ b/vme/src/hookmud.cpp
@@ -190,6 +190,11 @@ int cMultiHook::Read()
             send_to_descriptor("<mud-init/>", d);
             send_to_descriptor(g_cServerConfig.getLogo(), d);
             send_to_descriptor("By what name do they call you? ", d);
+            // GA-terminate the prompt: it is a partial line, and clients that
+            // have seen IAC GA before (any reconnect after a reboot) hold
+            // partial lines until a GA arrives - issue #395, missing name
+            // prompt in Mudlet after reboot.
+            send_to_descriptor("<go-ahead/>", d);
             break;
 
         case MULTI_HOST_CHAR:

--- a/vme/src/mplex/ClientConnector.cpp
+++ b/vme/src/mplex/ClientConnector.cpp
@@ -1446,7 +1446,16 @@ void cConHook::SetWebsocket(wsserver_tls *server, websocketpp::connection_hdl hd
 }
 
 // cConHook Constructor
-cConHook::cConHook()
+// Reset the per-session state of a connection to the same defaults a brand
+// new connection gets. Used by the constructor, and by test_mud_up() when
+// the MUD comes back after a reboot: the dead session's terminal setup
+// (pushed via MULTI_SETUP_CHAR), prompt bookkeeping and partial buffers must
+// not leak into the new session (issue #395).
+// Deliberately NOT touched here: the one-shot client detection state
+// (m_nSequenceCompare, m_nFirst), the serial line id (m_nLine, re-sent to
+// the MUD on reconnect), m_nId, m_aHost, the websocket fields and the
+// g_connection_list linkage.
+void cConHook::ResetSessionState()
 {
     m_bGobble = false;
     m_bColorCreate = false;
@@ -1455,22 +1464,12 @@ cConHook::cConHook()
     m_bColorRemove = false;
     m_bColorDelete = false;
     m_bColorInsert = false;
-    m_bGobble = false;
     m_nEscapeCode = 0;
     m_aOutput[0] = 0;
     m_aInputBuf[0] = 0;
-    m_nState = 0;
-
-    m_nSequenceCompare = 0;
-    m_nId = 0;
-    m_nFirst = 0;
-    m_nLine = 255;
 
     m_nPromptMode = 0;
     m_nPromptLen = 0;
-
-    // m_pWebsHdl = 0;
-    m_pWebsServer = nullptr;
 
     m_sSetup.echo = g_mplex_arg.g_bModeEcho;
     m_sSetup.redraw = g_mplex_arg.g_bModeRedraw;
@@ -1490,6 +1489,21 @@ cConHook::cConHook()
     m_sSetup.width = 80;
     m_sSetup.colour_convert = 0;
     m_nBgColor = CONTROL_BG_BLACK_CHAR;
+}
+
+cConHook::cConHook()
+{
+    ResetSessionState();
+
+    m_nState = 0;
+
+    m_nSequenceCompare = 0;
+    m_nId = 0;
+    m_nFirst = 0;
+    m_nLine = 255;
+
+    // m_pWebsHdl = 0;
+    m_pWebsServer = nullptr;
 
     m_pNext = g_connection_list;
     g_connection_list = this;

--- a/vme/src/mplex/ClientConnector.h
+++ b/vme/src/mplex/ClientConnector.h
@@ -33,6 +33,7 @@ public:
     void Write(ubit8 *pData, ubit32 nLen, int bCopy = TRUE);
 
     void Close(int bNotifyMud);
+    void ResetSessionState();
     char AddInputChar(ubit8 c);
     void AddString(char *str);
     void ParseInput();

--- a/vme/src/mplex/MUDConnector.cpp
+++ b/vme/src/mplex/MUDConnector.cpp
@@ -111,9 +111,25 @@ void test_mud_up()
         auto buf = diku::format_to_str("%s has begun rebooting... please wait.<br/>", g_mudname);
         con->SendCon(buf);
 
+        // Give the connection a fresh-session state so the dead session's
+        // terminal setup and prompt bookkeeping don't leak into the new one.
+        // TERM_INTERNAL is set exactly once by the W32 client's magic
+        // sequence and never re-sent, so preserve it - same guard as the
+        // MULTI_SETUP_CHAR handler below.
+        if (con->m_sSetup.emulation != TERM_INTERNAL)
+        {
+            con->ResetSessionState();
+        }
+        else
+        {
+            con->m_nPromptMode = 0;
+            con->m_nPromptLen = 0;
+        }
+
         con->m_pFptr = dumbMenuSelect;
         con->m_nState = 0;
         con->m_qInput.Flush();
+        con->m_qPaged.Flush();
         con->m_pFptr(con, "");
     }
 }

--- a/vme/src/mplex/MUDConnector.cpp
+++ b/vme/src/mplex/MUDConnector.cpp
@@ -184,11 +184,21 @@ void Control()
         // Took me forever to find this bug. When run in websockets mode
         // if the MUDHook is closed then only the motherport is open (4242).
         // Since we're on Websockets and no traffic comes in now on 4242,
-        // CaptainHook will be stuck forever in Wait(). In telnet mode that's
-        // not a problem because somebody will either trigger an existing connection
-        // or telnet to get a new connection. Then Wait() will finish and a new
-        // round begins.
-        n = g_CaptainHook.Wait(nullptr);
+        // CaptainHook will be stuck forever in Wait(). In telnet mode we
+        // used to block in Wait() until a client sent input (issue #395:
+        // players saw nothing after a reboot until they pressed enter).
+        // So while the MUD is down, wait with a 1 second timeout so the
+        // loop keeps calling test_mud_up() and reconnects by itself.
+        //
+        if (!g_MudHook.IsHooked())
+        {
+            timeval tv{1, 0}; // select() may modify it; fresh every iteration
+            n = g_CaptainHook.Wait(&tv);
+        }
+        else
+        {
+            n = g_CaptainHook.Wait(nullptr);
+        }
 
         if (n == -1)
         {


### PR DESCRIPTION
Fixes #395 — both symptoms, in three independent commits.

## Symptom 1: nothing after "Please be patient..." until the client presses Enter

Root cause: `Control()` parked in `g_CaptainHook.Wait(nullptr)` — `select()` with **no timeout** — while the MUD hook was down (telnet mode). The reconnect routine `test_mud_up()` was only reached again when some client fd showed activity; a keypress routed via `MudDown` → `test_mud_up()` and revived everything, which is exactly the reported behavior. The recovery machinery was already complete — only the retry loop stalled.

**Fix (commit 1)**: while the MUD hook is down, `Wait()` uses a 1-second timeout so the loop keeps retrying `test_mud_up()` on its own. When the MUD is up, the blocking `Wait(nullptr)` is unchanged. The websocket-mode `continue` workaround is left untouched.

⚠️ Operator note: with the loop actually retrying, `test_mud_up()`'s pre-existing give-up (600 failed attempts → `exit(1)`) now also applies in telnet mode after ~20–30 min of continuous MUD downtime — parity with websocket mode. `runmplex.sh` restarts mplex in that case.

## Symptom 2: Mudlet doesn't show "By what name do they call you?" after reboot

Root cause: the login burst is a bare partial line — no `<go-ahead/>`, no `<br/>`. GA-aware clients that have already seen IAC GA (after a reboot: every reconnected client, since every in-game prompt is GA-terminated) hold partial lines waiting for a GA that never comes. Fresh connections haven't seen a GA yet and fall back to timer-flushing — which is why it only broke on reconnect.

**Fix (commit 2)**: GA-terminate the name prompt (`hookmud.cpp`, one line). Telnet gets `IAC GA` via the existing `StripHTML` conversion; websockets pass the tag through as an inert element, exactly as already happens after every in-game prompt.

**Fix (commit 3, hardening)**: `test_mud_up()` now resets per-session connection state (terminal setup, prompt bookkeeping, partial buffers, paged output) so a reconnected connection starts from the same defaults as a fresh one. Extracted from the constructor into `cConHook::ResetSessionState()`. One-shot state is preserved: client detection (`m_nSequenceCompare`/`m_nFirst`), the serial line id (`m_nLine`), and `TERM_INTERNAL` emulation (the W32 client sends its magic sequence exactly once — same guard as the `MULTI_SETUP_CHAR` handler).

## Verification

- **Exact #395 repro, automated**: raw telnet client → connect (name prompt appears) → kill vme → "was broken" notice → restart vme → **name prompt + logo arrive with zero input sent**, and the burst ends with `IAC GA`. Passes.
- Websocket regression: the 3-client TLS reboot stress test (from #426) still passes — clients survive the reboot, mplex healthy.
- Full build warning-free; all 5 unit test suites pass.
- Outstanding manual check: Mudlet itself (can't be automated headless) — the GA fix matches Mudlet's documented prompt-display behavior, but a real Mudlet session after a reboot is the final confirmation, ideally by @iamnove who reported it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7CqwMRW1CqvQiBLrYPKqD